### PR TITLE
Add attribute value selector for @approved attribute of trans-unit

### DIFF
--- a/css/xliff.css
+++ b/css/xliff.css
@@ -145,14 +145,6 @@ trans-unit:before{
     color:gray;
 }
 
-trans-unit[approved="yes"] > * {
-    -oxy-editable: false;
-    background-color: #c8ffd2;
-    border: 1pt solid #82c896;
-    /* Add transparency */
-    color:rgba(50, 50, 50, 0.7);
-}
-
 trans-unit > *{
     padding-left:1em;
 }

--- a/css/xliff.css
+++ b/css/xliff.css
@@ -136,11 +136,11 @@ trans-unit{
 
 trans-unit:before{
     content:"Translation Unit, Approved: "
-    oxy_editor(
-        type, combo,
-        edit, "@approved",
-        values, "yes, no",
-        editable, true
+    oxy_checkbox(
+        edit, '@approved',
+        values, 'yes',
+        uncheckedValues, 'no',
+        labels, 'Approved'
     );
     color:gray;
 }

--- a/css/xliff.css
+++ b/css/xliff.css
@@ -145,6 +145,14 @@ trans-unit:before{
     color:gray;
 }
 
+trans-unit[approved="yes"] > * {
+    -oxy-editable: false;
+    background-color: #c8ffd2;
+    border: 1pt solid #82c896;
+    /* Add transparency */
+    color:rgba(50, 50, 50, 0.7);
+}
+
 trans-unit > *{
     padding-left:1em;
 }

--- a/css/xliff.css
+++ b/css/xliff.css
@@ -135,7 +135,13 @@ trans-unit{
 }
 
 trans-unit:before{
-    content:"Translation Unit";
+    content:"Translation Unit, Approved: "
+    oxy_editor(
+        type, combo,
+        edit, "@approved",
+        values, "yes, no",
+        editable, true
+    );
     color:gray;
 }
 

--- a/css/xliff2.css
+++ b/css/xliff2.css
@@ -224,11 +224,11 @@ trans-unit {
 }
 trans-unit:before{
     content:"Translation Unit, Approved: "
-    oxy_editor(
-        type, combo,
-        edit, "@approved",
-        values, "yes, no",
-        editable, true
+    oxy_checkbox(
+        edit, '@approved',
+        values, 'yes',
+        uncheckedValues, 'no',
+        labels, 'Approved'
     );
     color:gray;
 }

--- a/css/xliff2.css
+++ b/css/xliff2.css
@@ -222,9 +222,15 @@ tool:before {
 trans-unit {
   margin: 2px;
 }
-trans-unit:before {
-  content: "Translation Unit";
-  color: gray;
+trans-unit:before{
+    content:"Translation Unit, Approved: "
+    oxy_editor(
+        type, combo,
+        edit, "@approved",
+        values, "yes, no",
+        editable, true
+    );
+    color:gray;
 }
 trans-unit > * {
   padding-left: 1em;

--- a/css/xliff2.css
+++ b/css/xliff2.css
@@ -232,13 +232,6 @@ trans-unit:before{
     );
     color:gray;
 }
-trans-unit[approved="yes"] > * {
-    -oxy-editable: false;
-    background-color: #c8ffd2;
-    border: 1pt solid #82c896;
-    /* Add transparency */
-    color:rgba(50, 50, 50, 0.7);
-}
 trans-unit > * {
   padding-left: 1em;
 }

--- a/css/xliff2.css
+++ b/css/xliff2.css
@@ -232,6 +232,13 @@ trans-unit:before{
     );
     color:gray;
 }
+trans-unit[approved="yes"] > * {
+    -oxy-editable: false;
+    background-color: #c8ffd2;
+    border: 1pt solid #82c896;
+    /* Add transparency */
+    color:rgba(50, 50, 50, 0.7);
+}
 trans-unit > * {
   padding-left: 1em;
 }

--- a/css/xliff2.less
+++ b/css/xliff2.less
@@ -314,7 +314,13 @@ trans-unit{
 }
 
 trans-unit:before{
-    content:"Translation Unit";
+    content:"Translation Unit, Approved: "
+    oxy_editor(
+        type, combo,
+        edit, "@approved",
+        values, "yes, no",
+        editable, true
+    );
     color:gray;
 }
 

--- a/css/xliff2.less
+++ b/css/xliff2.less
@@ -324,14 +324,6 @@ trans-unit:before{
     color:gray;
 }
 
-trans-unit[approved="yes"] > * {
-    -oxy-editable: false;
-    background-color: #c8ffd2;
-    border: 1pt solid #82c896;
-    /* Add transparency */
-    color:rgba(50, 50, 50, 0.7);
-}
-
 trans-unit > *{
     padding-left:1em;
 }

--- a/css/xliff2.less
+++ b/css/xliff2.less
@@ -324,6 +324,14 @@ trans-unit:before{
     color:gray;
 }
 
+trans-unit[approved="yes"] > * {
+    -oxy-editable: false;
+    background-color: #c8ffd2;
+    border: 1pt solid #82c896;
+    /* Add transparency */
+    color:rgba(50, 50, 50, 0.7);
+}
+
 trans-unit > *{
     padding-left:1em;
 }

--- a/css/xliff2.less
+++ b/css/xliff2.less
@@ -315,11 +315,11 @@ trans-unit{
 
 trans-unit:before{
     content:"Translation Unit, Approved: "
-    oxy_editor(
-        type, combo,
-        edit, "@approved",
-        values, "yes, no",
-        editable, true
+    oxy_checkbox(
+        edit, '@approved',
+        values, 'yes',
+        uncheckedValues, 'no',
+        labels, 'Approved'
     );
     color:gray;
 }


### PR DESCRIPTION
It would be nice, if XLIFF files could be proofread directly in oXygen. Therefore it would be useful to set the `@approved` attribute of `<trans-unit>` elements in author mode.
