### PR TITLE
Highlight and lock approved trans-unit elements

### DIFF
--- a/css/xliff.css
+++ b/css/xliff.css
@@ -139,6 +139,14 @@ trans-unit:before{
     color:gray;
 }
 
+trans-unit[approved="yes"] > * {
+    -oxy-editable: false;
+    background-color: #c8ffd2;
+    border: 1pt solid #82c896;
+    /* Add transparency */
+    color:rgba(50, 50, 50, 0.7);
+}
+
 trans-unit > *{
     padding-left:1em;
 }

--- a/css/xliff2.css
+++ b/css/xliff2.css
@@ -226,6 +226,13 @@ trans-unit:before {
   content: "Translation Unit";
   color: gray;
 }
+trans-unit[approved="yes"] > * {
+    -oxy-editable: false;
+    background-color: #c8ffd2;
+    border: 1pt solid #82c896;
+    /* Add transparency */
+    color:rgba(50, 50, 50, 0.7);
+}
 trans-unit > * {
   padding-left: 1em;
 }

--- a/css/xliff2.less
+++ b/css/xliff2.less
@@ -318,6 +318,14 @@ trans-unit:before{
     color:gray;
 }
 
+trans-unit[approved="yes"] > * {
+    -oxy-editable: false;
+    background-color: #c8ffd2;
+    border: 1pt solid #82c896;
+    /* Add transparency */
+    color:rgba(50, 50, 50, 0.7);
+}
+
 trans-unit > *{
     padding-left:1em;
 }


### PR DESCRIPTION
Approved `<trans-unit>` elements (`@approved="yes")` should not be editable. This should also be visualized for the user.
