### PR TITLE
added advanced validation from XLIFF 2.1 Candidate OASIS Standard

### DIFF
--- a/NVDL/2.1/catalog.xml
+++ b/NVDL/2.1/catalog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+	<uri name="http://www.w3.org/XML/1998/namespace" uri="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:document:2.0" uri="xliff_core_2.0.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:changetracking:2.1" uri="change_tracking.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:fs:2.0" uri="fs.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:glossary:2.0" uri="glossary.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:matches:2.0" uri="matches.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:metadata:2.0" uri="metadata.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:resourcedata:2.0" uri="resource_data.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:sizerestriction:2.0" uri="size_restriction.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:validation:2.0" uri="validation.xsd"/>
+    <uri name="https://www.w3.org/2005/11/its/" uri="its.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:itsm:2.1" uri="itsm.xsd"/>
+</catalog>

--- a/NVDL/2.1/fs.sch
+++ b/NVDL/2.1/fs.sch
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Format Style module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="fs" uri="urn:oasis:names:tc:xliff:fs:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    
+    <sch:pattern id="fs1">
+        <sch:rule context="xlf:ec[@fs:fs]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#fs"
+                test="current()/@isolate='yes'">
+                The fs:fs attribute is used, but the isolated attribute is not set to 'yes'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="fs2">
+        <sch:rule context="xlf:ec[@fs:subFs]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFs"
+                test="current()/@isolated='yes'">
+                The fs:subFs attribute is used, but the isolated attribute is not set to 'yes'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="fs3">
+        <sch:rule context="xlf:*[@fs:subFs]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFs"
+                test="current()/@fs:fs">
+               The fs:subFs attribute is used, but fs:fs is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    
+    
+  
+        <sch:diagnostics>
+            <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+        </sch:diagnostics>
+</sch:schema>

--- a/NVDL/2.1/fs.xsd
+++ b/NVDL/2.1/fs.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:fs="urn:oasis:names:tc:xliff:fs:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:fs:2.0">
+
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="fs_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="a"/>
+      <xs:enumeration value="b"/>
+      <xs:enumeration value="bdo"/>
+      <xs:enumeration value="big"/>
+      <xs:enumeration value="blockquote"/>
+      <xs:enumeration value="body"/>
+      <xs:enumeration value="br"/>
+      <xs:enumeration value="button"/>
+      <xs:enumeration value="caption"/>
+      <xs:enumeration value="center"/>
+      <xs:enumeration value="cite"/>
+      <xs:enumeration value="code"/>
+      <xs:enumeration value="col"/>
+      <xs:enumeration value="colgroup"/>
+      <xs:enumeration value="dd"/>
+      <xs:enumeration value="del"/>
+      <xs:enumeration value="div"/>
+      <xs:enumeration value="dl"/>
+      <xs:enumeration value="dt"/>
+      <xs:enumeration value="em"/>
+      <xs:enumeration value="h1"/>
+      <xs:enumeration value="h2"/>
+      <xs:enumeration value="h3"/>
+      <xs:enumeration value="h4"/>
+      <xs:enumeration value="h5"/>
+      <xs:enumeration value="h6"/>
+      <xs:enumeration value="head"/>
+      <xs:enumeration value="hr"/>
+      <xs:enumeration value="html"/>
+      <xs:enumeration value="i"/>
+      <xs:enumeration value="img"/>
+      <xs:enumeration value="label"/>
+      <xs:enumeration value="legend"/>
+      <xs:enumeration value="li"/>
+      <xs:enumeration value="ol"/>
+      <xs:enumeration value="p"/>
+      <xs:enumeration value="pre"/>
+      <xs:enumeration value="q"/>
+      <xs:enumeration value="s"/>
+      <xs:enumeration value="samp"/>
+      <xs:enumeration value="select"/>
+      <xs:enumeration value="small"/>
+      <xs:enumeration value="span"/>
+      <xs:enumeration value="strike"/>
+      <xs:enumeration value="strong"/>
+      <xs:enumeration value="sub"/>
+      <xs:enumeration value="sup"/>
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="tbody"/>
+      <xs:enumeration value="td"/>
+      <xs:enumeration value="tfoot"/>
+      <xs:enumeration value="th"/>
+      <xs:enumeration value="thead"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="tr"/>
+      <xs:enumeration value="tt"/>
+      <xs:enumeration value="u"/>
+      <xs:enumeration value="ul"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Attributes -->
+
+  <xs:attribute name="fs" type="fs:fs_type"/>
+
+  <xs:attribute name="subFs" type="xs:string"/>
+
+</xs:schema>

--- a/NVDL/2.1/glossary.sch
+++ b/NVDL/2.1/glossary.sch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2' >
+    <sch:title>Schematron rules for checking the constraints of the Glossary module against XLIFF Vesrion &version; spec</sch:title>
+    <sch:ns prefix="gls" uri="urn:oasis:names:tc:xliff:glossary:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>    
+    <sch:pattern id="gls1">
+        <sch:rule context="gls:glossEntry[@id] | gls:translation[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#gls_id"
+                test="count(ancestor::gls:glossary//gls:glossEntry[@id=$id] | ancestor::gls:glossary//gls:translation[@id=$id])>1">
+                id duplication found among 'gls:glossEntry' and/or 'gls:translation' elements within the Glossary Module.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="gls2">
+        <sch:rule context="gls:glossEntry">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#glossentry" 
+                test="child::gls:translation or child::gls:definition">
+                Incomplete 'gls:glossEntry' element.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="gls3">
+        <sch:rule context="gls:glossEntry[@ref] | gls:translation[@ref]">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#gls_ref"
+                test="(not(contains($ref,'#')) and ancestor::xlf:unit//xlf:*[@id=$ref][ancestor-or-self::xlf:segment]) or 
+                (contains($ref,'#') and ancestor::xlf:unit//xlf:*[@id=substring-after($ref,'#')][ancestor-or-self::xlf:segment])">
+                'ref' attribute must point to a span of text within the same 'unit' (allowed referencing patterns: ref="#id" or ref="id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/NVDL/2.1/glossary.xsd
+++ b/NVDL/2.1/glossary.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:gls="urn:oasis:names:tc:xliff:glossary:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:glossary:2.0">
+
+
+  <!-- Elements for holding simple glossary data -->
+
+  <xs:element name="glossary">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="gls:glossEntry" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="glossEntry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="gls:term"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="gls:translation" />
+        <xs:element minOccurs="0" maxOccurs="1" ref="gls:definition" />
+        <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="term">
+    <xs:complexType mixed="true">
+      <xs:attribute name="source" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="translation">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="source" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="definition">
+    <xs:complexType mixed="true">
+      <xs:attribute name="source" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/informativeCopiesOf3rdPartySchemas/extensions/change_tracking.xsd
+++ b/NVDL/2.1/informativeCopiesOf3rdPartySchemas/extensions/change_tracking.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Change Tracking 2.0 has been demoted to an extension in XLIFF Version 2.1. Work on Change Tracking 2.2 is under way that should become a module again in XLIFF Vesrion 2.2 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ctr="urn:oasis:names:tc:xliff:changetracking:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:changetracking:2.0">
+
+
+  <!-- Elements for change tracking -->
+
+  <xs:element name="changeTrack">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="ctr:revisions"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="revisions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="ctr:revision"/>
+      </xs:sequence>
+      <xs:attribute name="appliesTo" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="currentVersion" use="optional" type="xs:NMTOKEN"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="revision">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="ctr:item"/>
+      </xs:sequence>
+      <xs:attribute name="author" use="optional"/>
+      <xs:attribute name="datetime" use="optional"/>
+      <xs:attribute name="version" use="optional" type="xs:NMTOKEN"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="item">
+    <xs:complexType mixed="true">
+      <xs:attribute name="property" use="required"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/informativeCopiesOf3rdPartySchemas/readme.txt
+++ b/NVDL/2.1/informativeCopiesOf3rdPartySchemas/readme.txt
@@ -1,0 +1,10 @@
+IMPORTANT WARNING
+Schema copies in this sub-folder are provided solely for implementers convenience and are NOT a part of the OASIS multipart product.
+These schemas belong to their respective owners and their use is governed by their owners' respective IPR policies.
+The support schemas are organized in folders per owner/maintainer.
+It is the implemnter's sole responsibility to ensure that their local copies of all schemas are the appropriate up to date versions.
+
+Included 3rd Party Support Schemas:
+-----------------------------------
+http://www.w3.org/2001/xml.xsd [http://www.w3.org/2009/01/xml.xsd] here under /w3c/xml.xsd
+change_tracking.xsd here under /extensions/change_tracking.xsd

--- a/NVDL/2.1/informativeCopiesOf3rdPartySchemas/w3c/xml.xsd
+++ b/NVDL/2.1/informativeCopiesOf3rdPartySchemas/w3c/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/NVDL/2.1/its.sch
+++ b/NVDL/2.1/its.sch
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+
+<sch:schema   
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    xmlns:mtc="urn:oasis:names:tc:xliff:matches:2.0"
+    xmlns:ctr="urn:oasis:names:tc:xliff:changetracking:2.1"
+	xmlns:res="urn:oasis:names:tc:xliff:resourcedata:2.0"
+	xmlns:its="http://www.w3.org/2005/11/its"
+	xmlns:itsm="urn:oasis:names:tc:xliff:itsm:2.1"
+    queryBinding='xslt2' 
+    schemaVersion='ISO19757-3'>
+    <sch:title>Schematron rules for checking the constraints of the ITS module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="its" uri="http://www.w3.org/2005/11/its"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    <!-- ctr removed not part of 2.1 release -->
+    <sch:ns prefix="itsm" uri="urn:oasis:names:tc:xliff:itsm:2.1"/>
+    <sch:ns prefix="mtc" uri="urn:oasis:names:tc:xliff:matches:2.0"/>
+    
+    <!-- ITS rules for mapping ITS data categories used in XLIFF 2.x. The rules are to be consumed by an ITS 2.0 conformant processor. The rules are ordered following the data category sub sections of the ITS module section in the XLIFF 2.1 specification.-->
+    
+    <its:rules version="2.0" queryLanguage="xpath">
+        
+        <!-- Rules for Allowed Characters are not needed, but covered by the W3C ITS namespace. -->
+        
+        <!-- Rules for Domain -->
+        <its:domainRule selector="//xlf:*[@itsm:domains]" domainPointer="@itsm:domains"/>
+        
+        <!-- Rules for Localization Quality Issue are not needed, but covered by the W3C ITS namespace. --> 
+        
+        <!-- Rules for Localization Quality Rating are not needed, but covered by the W3C ITS namespace. -->
+        
+        <!-- Rules for Text Analysis are not needed, but covered by the W3C ITS namespace. -->
+        
+        <!-- Rules for Localization Note. These rules cover the following cases:
+            
+        1) Note at file, no appliesTo attribute set: note relates to complete content of the file.
+        2) Note at group, no appliesTo attribute set: Note relates to complete content of the group.
+        3) Note at unit, appliesTo=target: note relates to target elements in unit. 
+        4) Note at file, appliesTo=target: note relates to target elements in file.
+        5) Note at group, appliesTo=target: note relates to target elements in group.
+        6) Note at unit, appliesTo=source: note relates to source elements in unit. 
+        7) Note at file, appliesTo=source: note relates to source elements in file.
+        8) Note at group, appliesTo=source: note relates to source elements in group.
+        
+        9) Annotation of the type="comment" with the Localization Note in the value attribute
+        
+        10) Note at unit without an appliesTo attribute cannot be properly parsed by a generic ITS Processor, as it can either apply to the whole unit content or else be referenced from an inline span by a comment annotation, hence these scenarios are not covered by the rules and the overlap of this data category with XLIFF features is considered partial.
+                
+        A priority attribute can appear on XLIFF <note>, it can be an integer 1-10. Value "1" means ITS alert and any other number ITS description.
+        -->
+        
+        <!-- Start of notes of type "alert" -->
+        <!-- 1) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source | //xlf:file/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]"
+            
+            locNoteType="alert"/>
+        <!-- 2) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source | //xlf:group/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[not(@appliesTo) and not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 3) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]"
+            
+            locNoteType="alert"/>
+        <!-- 4) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target" 
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 5) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 6) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 7) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 8) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        
+        
+        <!-- Start of notes of type "description" -->
+        <!-- 9 -->
+        <its:locNoteRule selector="//xlf:*[@type='comment' and @value]" locNotePointer="@value" locNoteType="description"/>
+        
+        
+        
+        
+        <!-- 1) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source | //xlf:file/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]" locNoteType="description"/>
+        <!-- 2) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source | //xlf:group/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[not(@appliesTo) and not(@priority) or @priority=1]" 
+            
+            locNoteType="description"/>
+        <!-- 3) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]"
+            
+            locNoteType="description"/>
+        <!-- 4) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target" 
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 5) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 6) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 7) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 8) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>        
+        
+        
+        <!-- Rules for Preserve Space: cannot be written since there are not pointer attributes for Preserve Space. But this limitation is OK since a processor can work with this data category locally.-->
+        
+        <!-- Rules for Translate -->
+        <its:translateRule selector="//xlf:*[@translate='no']" translate='no'/>
+        <its:translateRule selector="//xlf:*[@translate='yes']" translate='yes'/>
+        
+        <!-- Rules for External Resource -->
+        <its:externalResourceRefRule selector="//res:source | //res:target" externalResourceRefPointer="@href"/>
+        
+        <!-- Rules for Language Information -->
+        <its:langRule selector="//xlf:*[@xml:lang]" langPointer="@xml:lang"/>
+        <its:langRule selector="//xlf:*[@itsm:lang]" langPointer="@itsm:lang"/>
+        <its:langRule selector="//xlf:source[not(@xml:lang)]" langPointer="ancestor::*/@srcLang"/>
+        <its:langRule selector="//xlf:target[not(@xml:lang)]" langPointer="ancestor::*/@trgLang"/>
+        
+        <!-- Rules for MT Confidence: cannot be written since there is not pointer attribute for MT Confidence. But this limitation is OK since a processor can work with this data category locally. -->
+        
+        <!-- Rules for Provenance: cannot be written since there are no pointer attributes for the provenance records written in  XLIFF. But this limitation is OK since a processor can work with this data category locally. -->
+        
+        <!-- Rules for Terminology -->
+                
+        <its:termRule selector="//xlf:*[@type='term' or @type='its:term-no']"/>
+        <its:termRule selector="//xlf:*[@type='term' or @type='its:term-no'][@ref]" termInfoRefPointer="@ref"/>
+        <its:termRule selector="//xlf:*[@type='term' or @type='its:term-no'][@value]" termInfoPointer="@value"/>
+        
+        
+        
+        <!-- Rules for Directionality: This data category is not mapped to XLIFF 2.X -->
+        
+        <!-- Rules for Elements Within Text: This data category is not represented as metadata in XLIFF 2.X -->
+        
+        <!-- Rules for ID Value: This data category is not represented as metadata in XLIFF 2.X -->
+        
+        <!-- Rules for Locale Filter: cannot be written since there are no pointer attributes for locale filter written in  XLIFF. But this limitation is OK since a processor can work with this data category locally. -->
+        
+        <!-- Rules for Target Pointer -->
+        <its:targetPointerRule selector="//xlf:source" targetPointer="../xlf:target"/>
+        
+        <!-- Rules for storage size: The data category is not covered by the XLIFF 2.1 specification, so no rule is provided. -->
+        
+    </its:rules>
+    <!-- End of ITS Rules -->
+    <!-- Removed CTR -->
+    <!--<sch:pattern>
+        <sch:rule context="ctr:revision">
+            <sch:report test="@its:*[not(name()='its:toolRef')][not(name()='its:tool')][not(name()='its:revToolRef')][not(name()='its:revTool')]
+                [not(name()='its:revPersonRef')][not(name()='its:revPerson')][not(name()='its:revOrgRef')][not(name()='its:revOrg')]
+                [not(name()='its:org')][not(name()='its:provenanceRecordsRef')][not(name()='its:personRef')][not(name()='its:person')]
+                [not(name()='its:orgRef')][not(name()='its:annotatorsRef')]">
+                Invalid 'itsm' attribute used in 'revision'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>-->
+    <sch:pattern>
+        <sch:rule context="*[@its:*]| *[@itsm:*]">
+            <sch:assert test="ancestor-or-self::xlf:xliff/@its:version | ancestor-or-self::xlf:file/@its:version | 
+                            ancestor-or-self::xlf:unit/@its:version | ancestor-or-self::xlf:group/@version | ancestor-or-self::xlf:mrk/@its:version |
+                            ancestor-or-self::xlf:sm/@its:version | ancestor-or-self::mtc:match/@its:version | 
+                            ancestor-or-self::its:locQualityIssues/@its:version | ancestor-or-self::its:provenanceRecord/@its:version | 
+                            ancestor-or-self::its:provenanceRecords/@its:version">
+                ITS version is not bounded in the scope of ITS markup.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:annotatorsRef] | xlf:sm[@its:annotatorsRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:annotatorsRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssuesRef] | xlf:sm[@its:locQualityIssuesRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When used in ITS Localization Quality Issue Annotation, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+            <sch:report test="@its:locQualityIssueType or @its:locQualityIssueComment">
+                When the 'its:locQualityIssuesRef' attribute is used, the following attributes must be declared: 'its:locQualityIssueType' and 'its:locQualityIssueComment'.
+            </sch:report>
+            <sch:report test="@its:locQualityIssueSeverity or @its:locQualityIssueProfileRef or @its:locQualityIssueEnabled">
+                When the 'its:locQualityIssuesRef' attribute is used, the following attributes must be declared: 'its:locQualityIssueSeverity', 'its:locQualityIssueProfileRef' and 'its:locQualityIssueEnabled'..
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssueSeverity] | xlf:mrk[@its:locQualityIssueProfileRef] | 
+            xlf:sm[@its:locQualityIssueSeverity] | xlf:sm[@its:locQualityIssueProfileRef]">
+            <sch:report test="@its:locQualityIssuesRef">
+                When the 'its:locQualityIssueSeverity' or 'its:locQualityIssueProfileRef' attributes are used, the 'its:locQualityIssuesRef' must not be declared.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityRatingScore] | xlf:sm[@its:locQualityRatingScore]">
+            <sch:report test="@its:locQualityRatingVote">
+                When the 'its:locQualityRatingScore' attribute is used, the 'itms:locQualityRatingVote' attribute is not allowed.
+            </sch:report>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:locQualityRatingScore' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityRatingVote] | xlf:sm[@its:locQualityRatingVote]">
+            <sch:report test="@its:locQualityRatingScore">
+                When the 'its:locQualityRatingVote' attribute is used, the 'itms:locQualityRatingScore' attribute is not allowed.
+            </sch:report>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:locQualityRatingVote' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:locQualityRatingScoreThreshold]">
+            <sch:assert test="@its:locQualityRatingScore or ancestor::xlf:*[@its:locQualityRatingScore]">
+                The 'its:locQualityRatingScoreThreshold' attribute may be set only if 'its:locQualityRatingScore' is declared or inherited from upper levels.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:locQualityRatingVoteThreshold]">
+            <sch:assert test="@its:locQualityRatingVote or ancestor::xlf:*[@its:locQualityRatingVote]">
+                The 'its:locQualityRatingVoteThreshold' attribute may be set only if 'its:locQualityRatingVote' is declared or inherited from upper levels.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:taIdentRef] | xlf:sm[@its:taIdentRef]">
+            <sch:report test="@its:taSource or @its:taIdent">
+                When the 'its:taIdentRef' attribute is used, the following attributes are not allowed: 'its:taSource' and 'its:taIdent'.
+            </sch:report>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:taIdentRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:taSource] | xlf:sm[@its:taSource] |
+            xlf:mrk[@its:taIdent] | xlf:sm[@its:taIdent]">
+            <sch:report test="@its:taIdentRef">
+                When the 'its:taSource' or 'its:taIdent' attributes are used, the 'its:taIdentRef' attribute is not allowed.
+            </sch:report>
+            <sch:assert test="@its:taSource and @its:taIdent">
+                The pair of 'its:taSource' and 'its:taIdent'attributes must be present at the same time.
+            </sch:assert>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:taSource' and 'its:taIdent' attributes are used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:taClassRef] | xlf:sm[@its:taClassRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:taClassRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:lang] | xlf:sm[@its:lang]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:lang' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:mtConfidence] | xlf:sm[@its:mtConfidence]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:mtConfidence' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:provenanceRecordsRef] | xlf:sm[@its:provenanceRecordsRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:provenanceRecordsRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+            <sch:report test="@its:org or @its:orgRef or @its:person or 
+                @its:personRef or @its:revOrg or @its:revOrgRef or 
+                @its:revPerson or @its:revPersonRef or @its:revTool or
+                @its:revToolRef or @its:tool or @its:toolRef">
+                When the 'its:provenanceRecordsRef' attribute is used, the following attributes are not allowed: its:org, its:orgRef, its:person, its:personRef, its:revOrg,
+                its:revOrgRef, its:revPerson, its:revPersonRef, its:revTool, its:revToolRef, its:tool and its:toolRef.
+                
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:allowedCharacters] | xlf:mrk[@itsm:domains] | xlf:mrk[@itsm:lang] | xlf:mrk[@its:localeFilterList] |
+            xlf:sm[@its:allowedCharacters] | xlf:sm[@itsm:domains] | xlf:sm[@itsm:lang] | xlf:sm[@its:localeFilterList]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:allowedCharacters', 'itsm:domains' or 'its:localeFilterList attributes are used, the value of optional 'type' attribute must be set to 'its:generic'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssuesRef] | xlf:sm[@its:locQualityIssuesRef]">
+            <sch:report test="@its:locQualityIssueSeverity or @its:locQualityIssueProfileRef or @its:locQualityIssueEnabled">
+                If the 'its:locQualityIssuesRef' attribute is declared, the following attributes are not allowd: its:locQualityIssueSeverity, its:locQualityIssueProfileRef, and its:locQualityIssueEnabled".
+            </sch:report>
+            <sch:assert test="count(ancestor::xlf:unit//its:locQualityIssues[@xml:id=substring-after(current()/@its:locQualityIssuesRef , '#its=')])=1">
+                The value of the locQualityIssuesRef attribute must be relative URI (starting with "#its="), and the value after "#its=" must be one of the id attributes declared on a &lt;locQualityIssues> elements within the same 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssuesRef] | xlf:sm[@its:locQualityIssuesRef]">
+            <sch:report test="@its:locQualityIssueType or @its:locQualityIssueComment">
+                When 'its:locQualityIssuesRef' is declared, 'its:locQualityIssueType' and its:locQualityIssueComment are not allowed.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssueType] | xlf:mrk[@its:locQualityIssueComment] |
+                           xlf:sm[@its:locQualityIssueType] | xlf:sm[@its:locQualityIssueComment] ">
+            <sch:report test="@its:locQualityIssuesRef">
+                When 'its:locQualityIssueType' or 'its:locQualityIssueComment' are declared, 'its:locQualityIssuesRef' is not allowed.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+   <sch:pattern>
+        <sch:rule context="xlf:*[@its:annotatorsRef][not(contains(@its:annotatorsRef, ' '))]">
+            <sch:let name="ref" value="@its:annotatorsRef"/>
+            <sch:let name="its-dc-id" value="substring-before($ref,'|')"/>
+            <sch:report test="$its-dc-id!='allowed-characters' and $its-dc-id!='directionality' and $its-dc-id!='domain' and $its-dc-id!='elements-within-text' and
+                $its-dc-id!='external-resource' and $its-dc-id!='id-value' and $its-dc-id!='language-information' and
+                $its-dc-id!='locale-filter' and $its-dc-id!='localization-note' and $its-dc-id!='localization-quality-issue' and
+                $its-dc-id!='localization-quality-rating' and $its-dc-id!='mt-confidence' and $its-dc-id!='preserve-space' and
+                $its-dc-id!='provenance' and $its-dc-id!='storage-size' and $its-dc-id!='target-pointer' and
+                $its-dc-id!='terminology' and $its-dc-id!='text-analysis' and $its-dc-id!='translate'">
+                Invalid id used for the ITS datacategory <sch:value-of select="$its-dc-id"/>. Please see the Specification for guidelines on the value of this attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:annotatorsRef][(contains(@its:annotatorsRef, ' '))]">
+            <sch:let name="ids-string" value=" replace(@its:annotatorsRef, '\s+',' ')"/>
+            <sch:report  test="contains(substring-after($ids-string,'allowed-characters'),'allowed-characters')  or 
+                contains(substring-after($ids-string,'directionality'),'directionality') or 
+                contains(substring-after($ids-string,'domain'),'domain') or
+                contains(substring-after($ids-string,'elements-within-text'),'elements-within-text') or 
+                contains(substring-after($ids-string,'external-resource'),'external-resource') or
+                contains(substring-after($ids-string,'id-value'),'id-value') or 
+                contains(substring-after($ids-string,'language-information'),'language-information') or 
+                contains(substring-after($ids-string,'locale-filter'),'locale-filter') or 
+                contains(substring-after($ids-string,'localization-note'),'localization-note') or 
+                contains(substring-after($ids-string,'localization-quality-issue'),'localization-quality-issue') or 
+                contains(substring-after($ids-string,'localization-quality-rating'),'localization-quality-rating') or 
+                contains(substring-after($ids-string,'mt-confidence'),'mt-confidence') or 
+                contains(substring-after($ids-string,'preserve-space'),'preserve-space') or 
+                contains(substring-after($ids-string,'provenance'),'provenance') or 
+                contains(substring-after($ids-string,'storage-size'),'storage-size') or 
+                contains(substring-after($ids-string,'target-pointer'),'target-pointer') or 
+                contains(substring-after($ids-string,'terminology'),'terminology') or 
+                contains(substring-after($ids-string,'text-analysis'),'text-analysis') or 
+                contains(substring-after($ids-string,'translate'),'translate')"> 
+                Each ITS data category identifier must not be used more than once.
+            </sch:report>
+            <sch:report test="string-length(replace(replace(current()/@its:annotatorsRef,'\|[^\s]+\s*',''), 'allowed-characters|directionality|domain|elements-within-text|external-resource|id-value|language-information|locale-filter|localization-note|localization-quality-issue|localization-quality-rating|mt-confidence|preserve-space|provenance|storage-size|target-pointer|terminology|text-analysis|translate',''))!=0">
+                'annotatorsRef' contains illegal value for ITS datacategories.
+            </sch:report>
+         </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:annotatorsRef]">
+            <sch:report  test="matches(@its:annotatorsRef,'\|\s+') or matches(@its:annotatorsRef,'\s+\|')"> 
+                The vertical bar in @its:annotatorsRef must not be surrounded by whitespace.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:locQualityIssue">
+            <sch:assert test="@locQualityIssueType or @locQualityIssueComment">
+                At least one of the attributes locQualityIssueType or locQualityIssueComment must be set.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:provenanceRecord">
+            <sch:assert test="@org or @orgRef or @person or 
+                @personRef or @revOrg or @revOrgRef or 
+                @revPerson or @revPersonRef or @revTool or
+                @revToolRef or @tool or @toolRef">
+                At least one of the followings must be set: its:org, its:orgRef, its:person, its:personRef, its:revOrg,
+                its:revOrgRef, its:revPerson, its:revPersonRef, its:revTool, its:revToolRef, its:tool and its:toolRef.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:locQualityIssues | its:provenanceRecords[ancestor::xlf:unit]">
+            <sch:let name="id" value="@xml:id"/>
+            <sch:let name="counter" value="count(ancestor::xlf:unit//its:locQualityIssues[@xml:id=$id] | ancestor::xlf:unit//its:provenanceRecords[@xml:id=$id])"/>
+            <sch:assert test="$counter=1">
+                Value of 'id' must be unique among all of  &lt;locQualityIssues> and &lt;provenanceRecords> elements within the enclosing 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:provenanceRecords[ancestor::xlf:group][not(ancestor::xlf:unit)]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="counter" value="count(ancestor::xlf:group[1]//its:provenanceRecords[@id=$id][not(ancestor::xlf:unit)])"/>
+            <sch:assert test="$counter=1">
+                Value of 'id' must be unique among all of  &lt;provenanceRecords> elements within the enclosing 'group'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:provenanceRecords[ancestor::xlf:file][not(ancestor::xlf:unit)][not(ancestor::xlf:group)]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="counter" value="count(ancestor::xlf:file//its:provenanceRecords[@id=$id][not(ancestor::xlf:group)][not(ancestor::xlf:unit)])"/>
+            <sch:assert test="$counter=1">
+                Value of 'id' must be unique among all of  &lt;provenanceRecords> elements within the enclosing 'file'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:locQualityIssuesRef]">
+            <sch:assert test="not(@its:locQualityIssueSeverity)">
+                If 'its:locQualityIssuesRef' attribute is declared, the 'its:locQualityIssueSeverity' must not be used. 
+            </sch:assert>
+            <sch:assert test="not (@its:locQualityIssueProfileRef) ">
+                If 'its:locQualityIssuesRef' attribute is declared, the 'its:locQualityIssueProfileRef' must not be used. 
+            </sch:assert>
+            <sch:assert test="not(@its:locQualityIssueEnabled)">
+                If 'its:locQualityIssuesRef' attribute is declared, the 'its:locQualityIssueEnabled' must not be used. 
+            </sch:assert>
+        </sch:rule>        
+    </sch:pattern>
+</sch:schema>

--- a/NVDL/2.1/its.xsd
+++ b/NVDL/2.1/its.xsd
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  xmlns:its="http://www.w3.org/2005/11/its" xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+  targetNamespace="http://www.w3.org/2005/11/its">
+
+
+  <!-- Import -->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+    schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="ITSVersion">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="2.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="locFilterType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="include"/>
+      <xs:enumeration value="exclude"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="issueType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="terminology"/>
+      <xs:enumeration value="mistranslation"/>
+      <xs:enumeration value="omission"/>
+      <xs:enumeration value="untranslated"/>
+      <xs:enumeration value="addition"/>
+      <xs:enumeration value="duplication"/>
+      <xs:enumeration value="inconsistency"/>
+      <xs:enumeration value="grammar"/>
+      <xs:enumeration value="legal"/>
+      <xs:enumeration value="register"/>
+      <xs:enumeration value="locale-specific-content"/>
+      <xs:enumeration value="locale-violation"/>
+      <xs:enumeration value="style"/>
+      <xs:enumeration value="characters"/>
+      <xs:enumeration value="misspelling"/>
+      <xs:enumeration value="typographical"/>
+      <xs:enumeration value="formatting"/>
+      <xs:enumeration value="inconsistent-entities"/>
+      <xs:enumeration value="numbers"/>
+      <xs:enumeration value="markup"/>
+      <xs:enumeration value="pattern-problem"/>
+      <xs:enumeration value="whitespace"/>
+      <xs:enumeration value="internationalization"/>
+      <xs:enumeration value="length"/>
+      <xs:enumeration value="non-conformance"/>
+      <xs:enumeration value="uncategorized"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="score">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:maxInclusive value="100.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="confidence">
+    <xs:restriction base="xs:double">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="yesNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Attributes -->
+  
+  <xs:attribute name="version" type="its:ITSVersion"/>
+
+  <xs:attribute name="allowedCharacters" type="xs:string"/>
+
+  <xs:attribute name="annotatorsRef" type="xs:string"/>
+
+  <!-- <xs:attribute name="domains" type="xs:string"/> moved to itsm.xsd as it does not exist in the W3C namespace -->
+  
+  <!-- <xs:attribute name="lang" type="xs:language"/> moved to itsm.xsd as it does not exist in the W3C namespace that reuses xml:lang -->
+  
+  <xs:attribute name="localeFilterList" type="xs:string" default="*"/>
+
+  <xs:attribute name="localeFilterType" type="its:locFilterType" default="include"/>
+
+  <xs:attribute name="locQualityIssueComment" type="xs:string"/>
+
+  <xs:attribute name="locQualityIssueEnabled" type="its:yesNo" default="yes"/>
+
+  <xs:attribute name="locQualityIssueProfileRef" type="xs:anyURI"/>
+
+  <xs:attribute name="locQualityIssuesRef" type="xs:anyURI"/>
+
+  <xs:attribute name="locQualityIssueSeverity" type="its:score"/>
+
+  <xs:attribute name="locQualityIssueType" type="its:issueType"/>
+
+  <xs:attribute name="locQualityRatingProfileRef" type="xs:anyURI"/>
+
+  <xs:attribute name="locQualityRatingScore" type="its:score"/>
+
+  <xs:attribute name="locQualityRatingScoreThreshold" type="its:score"/>
+
+  <xs:attribute name="locQualityRatingVote" type="xs:integer"/>
+
+  <xs:attribute name="locQualityRatingVoteThreshold" type="xs:integer"/>
+
+  <xs:attribute name="mtConfidence" type="its:confidence"/>
+
+  <xs:attribute name="org" type="xs:string"/>
+
+  <xs:attribute name="orgRef" type="xs:anyURI"/>
+
+  <xs:attribute name="person" type="xs:string"/>
+
+  <xs:attribute name="personRef" type="xs:anyURI"/>
+
+  <xs:attribute name="provenanceRecordsRef" type="xs:anyURI"/>
+
+  <xs:attribute name="revOrg" type="xs:string"/>
+
+  <xs:attribute name="revOrgRef" type="xs:anyURI"/>
+
+  <xs:attribute name="revPerson" type="xs:string"/>
+
+  <xs:attribute name="revPersonRef" type="xs:anyURI"/>
+
+  <xs:attribute name="revTool" type="xs:string"/>
+
+  <xs:attribute name="revToolRef" type="xs:anyURI"/>
+
+  <xs:attribute name="taClassRef" type="xs:anyURI"/>
+
+  <xs:attribute name="taConfidence" type="its:confidence"/>
+
+  <xs:attribute name="taIdent" type="xs:string"/>
+
+  <xs:attribute name="taIdentRef" type="xs:anyURI"/>
+
+  <xs:attribute name="taSource" type="xs:string"/>
+
+  <xs:attribute name="termConfidence" type="its:confidence"/>
+
+  <xs:attribute name="tool" type="xs:string"/>
+
+  <xs:attribute name="toolRef" type="xs:anyURI"/>
+
+
+  <!-- Elements -->
+
+  <xs:element name="locQualityIssues">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="its:locQualityIssue"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:id" use="required"/>
+      <xs:attribute name="version" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="locQualityIssue">
+    <xs:complexType mixed="false">
+      <xs:attribute name="version" use="optional"/>
+      <xs:attribute name="locQualityIssueType" use="optional"/>
+      <xs:attribute name="locQualityIssueComment" use="optional"/>
+      <xs:attribute name="locQualityIssueSeverity" use="optional"/>
+      <xs:attribute name="locQualityIssueProfileRef" use="optional"/>
+      <xs:attribute name="locQualityIssueEnabled" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="provenanceRecords">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="its:provenanceRecord"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:id" use="required"/>
+      <xs:attribute name="version" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="provenanceRecord">
+    <xs:complexType mixed="false">
+      <xs:attribute name="version" use="optional"/>
+      <xs:attribute name="org" use="optional"/>
+      <xs:attribute name="orgRef" use="optional"/>
+      <xs:attribute name="person" use="optional"/>
+      <xs:attribute name="personRef" use="optional"/>
+      <xs:attribute name="revOrg" use="optional"/>
+      <xs:attribute name="revOrgRef" use="optional"/>
+      <xs:attribute name="revPerson" use="optional"/>
+      <xs:attribute name="revPersonRef" use="optional"/>
+      <xs:attribute name="revTool" use="optional"/>
+      <xs:attribute name="revToolRef" use="optional"/>
+      <xs:attribute name="tool" use="optional"/>
+      <xs:attribute name="toolRef" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/itsm.xsd
+++ b/NVDL/2.1/itsm.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  xmlns:itsm="urn:oasis:names:tc:xliff:itsm:2.1" xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+  targetNamespace="urn:oasis:names:tc:xliff:itsm:2.1">
+
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0" schemaLocation="xliff_core_2.0.xsd"/>
+
+
+  
+  <!-- Attributes -->
+
+  <xs:attribute name="domains" type="xs:string"/>
+
+  <xs:attribute name="lang" type="xs:language"/>
+</xs:schema>

--- a/NVDL/2.1/matches.sch
+++ b/NVDL/2.1/matches.sch
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Translation Candidate Annotation module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="mtc" uri="urn:oasis:names:tc:xliff:matches:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/> 
+    <sch:pattern id="K5MTC">
+        <sch:title>The value [of id] must be unique among all 'data' id attribute values within the enclosing 'originalData' element</sch:title>
+        <sch:rule context="xlf:data[ancestor::mtc:matches]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:data[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'data' elements 
+                within the enclosing 'originalData' in the MTC module.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K6MTC-S">
+        <sch:title>Except for the above exception [target duplication], the value [of id attribute] must be unique among all of the above 
+            [segment, ignorable, mkr, sm,pc, sc, ec, ph] within the enclosing 'revision' element</sch:title>
+        <sch:rule context="xlf:source[ancestor::mtc:match]//xlf:*[@id]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:report see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:source//xlf:*[@id=$id])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more then once among inline and/or 'segmen'/'ignorable' 
+                elements within the enclosing 'revision'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K6MTC-T">
+        <sch:title>The inline elements enclosed by a 'target' element must use the duplicate id values of their corresponding inline elements enclosed within the sibling 'source' element if and only if those corresponding elements exist</sch:title>
+        <sch:rule context="xlf:target[ancestor::mtc:match]//xlf:*[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="counter" value="count(ancestor::mtc:match//xlf:*[@id=$id])"/>
+            <!-- If the counter is 1, then the id is unique and therefore valid -->
+            <!-- If the counter is 2 (duplication exsists), the duplication must be 
+            in the sibling source, have the same name and contain same attributes-->
+            <!-- If the counter is more than 2 or the duplication is not in the right 
+            position, then an error will be reported -->
+            <sch:assert see="&this-loc;/&name;-&stage;.html#id"
+                test="($counter=1) or ($counter=2 and
+                count(ancestor::mtc:match//xlf:source//xlf:*[@id=$id]
+                [local-name()= local-name(current())])=1)">
+                Invalid id used for element '<sch:name/>'. It must duplicate the 
+                id of its corresponding element, enclosed within the 'source' 
+                element or be unique in the scope of 'revision'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc-F15">
+        <sch:title>dataRef attribute must point to a data element within the same mtc:match</sch:title>
+        <sch:rule context="xlf:*[@dataRef][ancestor::mtc:match]">
+            <sch:assert test="ancestor::mtc:match/xlf:originalData/xlf:data[@id=current()/@dataRef]">
+                'dataRef' attribute must point to a 'data' element within the same 'mtc:match' (allowed referencing pattern: dataRef="data-id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc-F16">
+        <sch:title>dataRefEnd attribute must point to a data element within the same mtc:match</sch:title>
+        <sch:rule context="xlf:pc[@dataRefEnd][ancestor::mtc:match]">
+            <sch:assert test="ancestor::mtc:match/xlf:originalData/xlf:data[@id=current()/@dataRefEnd]">
+                'dataRefEnd' attribute must point to a 'data' element within the same 'mtc:match' (allowed referencing pattern: dataRefEnd="data-id").
+            </sch:assert>
+            <sch:assert test="@dataRefStart">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc-F17">
+        <sch:title>dataRefStart attribute must point to a data element within the same mtc:match</sch:title>
+        <sch:rule context="xlf:pc[@dataRefStart][ancestor::mtc:match]">
+            <sch:assert test="ancestor::mtc:match/xlf:originalData/xlf:data[@id=current()/@dataRefStart]">
+                'dataRefStart' attribute must point to a 'data' element within the same 'mtc:match' (allowed referencing pattern: dataRefStart="data-id").
+            </sch:assert>
+            <sch:assert test="@dataRefEnd">
+                'dataRefStart' and 'dataRefEnd' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc1">
+        <sch:rule context="mtc:match[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#candidates_id"
+                test="following-sibling::mtc:match[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'match' elements within the enclosing 'matches' element.
+            </sch:report>
+        </sch:rule>        
+    </sch:pattern>
+    <sch:pattern id="mtc2">
+        <sch:rule context="mtc:match">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#candidates_ref"
+                test="(not(contains($ref,'#')) and ancestor::xlf:unit//xlf:*[@id=$ref][ancestor-or-self::xlf:segment]) or 
+                (contains($ref,'#') and ancestor::xlf:unit//xlf:*[@id=substring-after($ref,'#')][ancestor-or-self::xlf:segment])">
+                'ref' attribute must point to a span of text within the same 'unit' (allowed referencing patterns: ref="#id" or ref="id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc3">
+        <sch:rule context="mtc:match[@subType]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#candidates_subtype"
+                test="@type" >
+                'subType' attribute is used, but the 'type attribute is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc4">
+        <sch:rule context="mtc:match//xlf:sc[@isolated='no' or not(@isolated)]">
+            <sch:assert test="ancestor::mtc:match//xlf:ec[@startRef=current()/@id]">
+                There must not be any unhandled orphan elements. The 'ec' element corresponding to this start code is missing in the same 'ctr:contentItem'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc5">
+        <sch:rule context="mtc:match//xlf:sm">
+            <sch:assert test="ancestor::mtc:match//xlf:em[@startRef=current()/@id]">
+                There must not be any unhandled orphan elements. The 'em' element corresponding to this start marker is missing in the same 'ctr:contentItem'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/NVDL/2.1/matches.xsd
+++ b/NVDL/2.1/matches.xsd
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:mtc="urn:oasis:names:tc:xliff:matches:2.0"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:matches:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0"
+      schemaLocation="xliff_core_2.0.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:xliff:metadata:2.0"
+      schemaLocation="metadata.xsd"/>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="similarity">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:maxInclusive value="100.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="typeValues">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="am"/>
+      <xs:enumeration value="mt"/>
+      <xs:enumeration value="icm"/>
+      <xs:enumeration value="idm"/>
+      <xs:enumeration value="tb"/>
+      <xs:enumeration value="tm"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Elements -->
+
+  <xs:element name="matches">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="mtc:match"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="match">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="mda:metadata"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:originalData"/>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:target"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="matchQuality" use="optional" type="mtc:similarity"/>
+      <xs:attribute name="matchSuitability" use="optional" type="mtc:similarity"/>
+      <xs:attribute name="origin" use="optional"/>
+      <xs:attribute name="ref" use="required" type="xs:anyURI"/>
+      <xs:attribute name="reference" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="similarity" use="optional" type="mtc:similarity"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="mtc:typeValues"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/metadata.sch
+++ b/NVDL/2.1/metadata.sch
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Metadata module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="mda" uri="urn:oasis:names:tc:xliff:metadata:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    
+    <sch:pattern id="mda1">
+        <sch:rule context=" mda:metaGroup[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#meta_id"
+                test="ancestor::mda:metadata[@id=$id] or count(ancestor::mda:metadata//mda:metaGroup[@id=$id])>1">
+                id duplication found. The value of id attribute (<sch:value-of select="$id"/>) must be unique among all 'mda:metaGroup' elements and the ancestor 'mda:metedata' element within the scope of the module. 
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/NVDL/2.1/metadata.xsd
+++ b/NVDL/2.1/metadata.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:metadata:2.0">
+
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="appliesTo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="source"/>
+      <xs:enumeration value="target"/>
+      <xs:enumeration value="ignorable"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Elements for holding custom metadata -->
+
+  <xs:element name="metadata">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="mda:metaGroup" />
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="metaGroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="mda:metaGroup"/>
+          <xs:element ref="mda:meta"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="category" use="optional"/>
+      <xs:attribute name="appliesTo" use="optional" type="mda:appliesTo"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="meta">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/resource_data.sch
+++ b/NVDL/2.1/resource_data.sch
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Resource Data module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="res" uri="urn:oasis:names:tc:xliff:resourcedata:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    <sch:pattern id="res1">
+        <sch:rule context="res:resourceItemRef[@id] | res:resourceItem[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_resourceItemRef"
+                test="count(ancestor::res:resourceData//res:resourceItem[@id=$id] | ancestor::res:resourceData//res:resourceItemRef[@id=$id])>1">
+                id duplication found among 'res:resourceItemRef' and/or 'res:resourceItem' elements within the enclosing 'resourceData' element. 
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res2">
+        <sch:rule context="res:resourceItem[not(@mimeType)]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_resourceItem"
+                test="./res:source/* and ./res:target/*">
+                The children 'res:source' and/or 'res:target' elements are empty, but the mimeType attribute is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res3">
+        <sch:rule context="res:source">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_source"
+                test="not(@href) and not(child::node())">
+                'res:source' element must not be empty when the 'href' attribute is missing.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_source"
+                test="@href and  child::node()">
+                'res:source' element must be empty when containing 'href' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res4">
+        <sch:rule context="res:source[@xml:lang]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:let name="srcLang" value="/xlf:xliff/@srcLang"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_source"
+                test="lang($srcLang)">
+                xml:lang attribute of 'res:source' element and 'srcLang' of enclosing 'xliff' are not matching.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res5">
+        <sch:rule context="res:target">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_target"
+                test="not(@href) and not(child::node())">
+                'res:target' element must not be empty when the 'href' attribute is missing.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_target"
+                test="@href and  child::node()">
+                'res:target' element must be empty when containing 'href' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res6">
+        <sch:rule context="res:target[@xml:lang]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:let name="trgLang" value="ancestor::xlf:xliff/@trgLang"/>
+            <sch:assert diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#res_target"
+                test="lang($trgLang)">
+                xml:lang attribute of 'res:target' element and 'trgLang' of enclosing 'xliff' are not matching.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res7">
+        <sch:rule context="res:resourceItemRef">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_ref"
+                test="ancestor::xlf:file//res:resourceData/res:resourceItem[@id=$ref]">
+                The 'res:resourceItem' element, to which the 'res:resourceItemRef' is pointing was not found at the file level (allowed referencing pattern: ref="id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+
+
+</sch:schema>

--- a/NVDL/2.1/resource_data.xsd
+++ b/NVDL/2.1/resource_data.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:res="urn:oasis:names:tc:xliff:resourcedata:2.0"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:resourcedata:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0"
+      schemaLocation="xliff_core_2.0.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+    schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+  
+  <!-- Elements -->
+
+  <xs:element name="resourceData">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="res:resourceItemRef"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="res:resourceItem"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="resourceItemRef">
+    <xs:complexType mixed="false">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="required" type="xs:NMTOKEN"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="resourceItem">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="res:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="res:target"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="res:reference"/>
+      </xs:sequence>
+      <xs:attribute name="mimeType" use="optional"/>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="context" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="source">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="target">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="reference">
+    <xs:complexType mixed="false">
+      <xs:attribute name="href" use="required"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/size_restriction.sch
+++ b/NVDL/2.1/size_restriction.sch
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Size and Length Restriction module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="slr" uri="urn:oasis:names:tc:xliff:sizerestriction:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>    
+    <sch:pattern id="slr1">
+        <sch:rule context="xlf:*[@slr:sizeInfoRef]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#slr_size_info"
+                test="not(@slr:sizeInfo)">
+                The slr:sizeInfoRef and slr:sizeInfo attributes cannot appear together. 
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/NVDL/2.1/size_restriction.xsd
+++ b/NVDL/2.1/size_restriction.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:slr="urn:oasis:names:tc:xliff:sizerestriction:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:sizerestriction:2.0">
+
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="normalization_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="nfc"/>
+      <xs:enumeration value="nfd"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Attributes for size and length restriction used on core elements-->
+
+  <xs:attribute name="equivStorage" type="xs:string"/>
+
+  <xs:attribute name="sizeInfo" type="xs:string"/>
+
+  <xs:attribute name="sizeInfoRef" type="xs:NMTOKEN"/>
+
+  <xs:attribute name="sizeRestriction" type="xs:string"/>
+
+  <xs:attribute name="storageRestriction" type="xs:string"/>
+
+
+  <!-- Elements for size and length restriction -->
+
+  <xs:element name="profiles">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="slr:normalization" />
+        <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="generalProfile" use="optional"/>
+      <xs:attribute name="storageProfile" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="normalization">
+    <xs:complexType mixed="false">
+      <xs:attribute name="general" use="optional" type="slr:normalization_type" default="none"/>
+      <xs:attribute name="storage" use="optional" type="slr:normalization_type" default="none"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="data">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="profile" use="required"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/validation.sch
+++ b/NVDL/2.1/validation.sch
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Validation module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="val" uri="urn:oasis:names:tc:xliff:validation:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>    
+    <sch:pattern id="val1">
+        <sch:rule context="val:rule" see="&this-loc;/&name;-&stage;.html#val_rule">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" test="@isPresent and (@isNotPresent or @startsWith or @ endsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="@isNotPresent and (@isPresent or @startsWith or @ endsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="@startsWith and (@isPresent or @isNotPresent  or @ endsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="@endsWith and (@isPresent or @isNotPresent  or @ startsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="not(@isPresent) and not(@isNotPresent) and not(@startsWith) and not(@ endsWith) and not(@*[namespace-uri()!='urn:oasis:names:tc:xliff:validation:2.0'])">
+                When native module attributes isPresent, isNotPresent, startsWith or endsWith are not used, a custom attribute must be set for 'val:rule' element.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="val2">
+        <sch:rule context="val:rule[@occurs]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#val_occurs" test="not(@isPresent)">
+                The occure attribute can only be used in pair with isPresent
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="val3">
+        <sch:rule context="val:rule[@existsInSource]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#val_existsInSource"
+                test="(@isPeresent and not(@startsWith) and not(@endsWith)) or 
+                              (@startsWith and not(@isPeresent) and not(@endsWith)) or 
+                              (@endsWith and not(@isPeresent) and not(@startsWith))">
+                The 'existsInSourc'e attribute must be used with exactly one of 'isPresent', 'startsWith' or 'endsWith' attributes. 
+            </sch:assert>
+        </sch:rule> 
+    </sch:pattern>
+    <sch:pattern id="val4">
+        <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+        <sch:rule context="val:rule[@disabled='yes']">
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#val_disabled"
+                test="local-name(../..)='file'">
+                The disabled attribute cannot be set to 'yes' when the Validation Module is at the 'file' level.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!--<sch:pattern>
+        <sch:rule context="val:rule[@startsWith][not(@disabled) or @disabled='no']">
+            <sch:let name="start-pattern" value="@startsWith"/>
+            <sch:let name="eligible-targets" value="count(../..//xlf:target[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])])"/>
+            <sch:let name="valid-targets" value="count(../..//xlf:target[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][starts-with(.,$start-pattern)])"/>
+            <sch:let name="eligible-sources" value="count(../..//xlf:source[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])])"/>
+            <sch:let name="valid-sources" value="count(../..//xlf:source[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][starts-with(.,$start-pattern)])"/>
+            <sch:assert test="((not(@existsInSource) or @existsInSource='no')) or
+                (@existsInSource='yes' and $eligible-sources=$valid-sources) and $valid-targets=$eligible-targets">
+                The startsWith pattern is violated.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>-->
+   <!-- <sch:pattern>
+        <sch:rule context="val:rule[@isPresent][local-name(../..)='file']">
+            <sch:let name="isPresent" value="current()/@isPresent"/>
+            <sch:let name="unit-override" value="count(../..//xlf:unit[descendant::val:rule[@isPresent=$isPresent][@disabled='yes']])"/>
+            <sch:let name="group-override" value="count(../..//xlf:group[descendant::val:rule[@isPresent=$isPresent][@disabled='yes']])"/>
+            <sch:let name="tester" value="../..//xlf:target"/>
+            <sch:report test="true()">
+                REPORTER <sch:value-of select="$override"/>
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>-->
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="spec-quote"></sch:diagnostic>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/NVDL/2.1/validation.xsd
+++ b/NVDL/2.1/validation.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:val="urn:oasis:names:tc:xliff:validation:2.0"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:validation:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0"
+      schemaLocation="xliff_core_2.0.xsd"/>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="normalization_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="nfc"/>
+      <xs:enumeration value="nfd"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Elements -->
+
+  <xs:element name="validation">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="val:rule"/>
+      </xs:sequence>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="rule">
+    <xs:complexType mixed="false">
+      <xs:attribute name="isPresent" use="optional"/>
+      <xs:attribute name="occurs" use="optional" type="xs:positiveInteger"/>
+      <xs:attribute name="isNotPresent" use="optional"/>
+      <xs:attribute name="startsWith" use="optional"/>
+      <xs:attribute name="endsWith" use="optional"/>
+      <xs:attribute name="existsInSource" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="caseSensitive" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="normalization" use="optional" type="val:normalization_type" default="nfc"/>
+      <xs:attribute name="disabled" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/xliff_2_advanced_validation.nvdl
+++ b/NVDL/2.1/xliff_2_advanced_validation.nvdl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://purl.oclc.org/dsdl/nvdl/ns/structure/1.0" startMode="core">
+    <mode name="core">
+        <namespace ns="urn:oasis:names:tc:xliff:document:2.0">
+            <validate schema="xliff_core_2.0.xsd" useMode="modules"/>
+            <validate schema="xliff_core_2.0.xsd" useMode="attach-all"/>
+            <validate schema="xliff_core_2.1.sch" useMode="attach-all"/>
+            <validate schema="matches.sch" useMode="attach-all"/>
+            <validate schema="glossary.sch" useMode="attach-all"/>
+            <validate schema="fs.sch" useMode="attach-all"/>
+            <validate schema="resource_data.sch" useMode="attach-all"/>
+            <validate schema="size_restriction.sch" useMode="attach-all"/>
+            <!-- <validate schema="change_tracking.sch" useMode="attach-all"/>  -->
+            <validate schema="metadata.sch" useMode="attach-all"/>
+            <validate schema="validation.sch" useMode="attach-all"/>
+            <validate schema="its.sch" useMode="attach-all"/>
+        </namespace>
+    </mode>
+    <mode name="modules">
+        <namespace ns="urn:oasis:names:tc:xliff:matches:2.0">
+            <validate schema="matches.xsd" useMode="attach-all" />
+        </namespace>
+        <namespace ns="urn:oasis:names:tc:xliff:glossary:2.0">
+            <validate schema="glossary.xsd"/>
+        </namespace>
+        <namespace ns="urn:oasis:names:tc:xliff:metadata:2.0">
+            <validate schema="metadata.xsd"/>
+        </namespace>
+        <namespace ns="urn:oasis:names:tc:xliff:fs:2.0" match="attributes">
+            <validate schema="fs.xsd"/>
+        </namespace>
+        <namespace ns="urn:oasis:names:tc:xliff:resourcedata:2.0">
+            <validate schema="resource_data.xsd"/>
+        </namespace>
+        <namespace ns="urn:oasis:names:tc:xliff:sizerestriction:2.0">
+            <validate schema="size_restriction.xsd"/>
+        </namespace>
+        <!--<namespace ns="urn:oasis:names:tc:xliff:changetracking:2.1">
+            <validate schema="change_tracking.xsd"/>
+        </namespace>-->
+        <namespace ns="urn:oasis:names:tc:xliff:validation:2.0">
+            <validate schema="validation.xsd"/>
+        </namespace>
+        <namespace ns="urn:oasis:names:tc:xliff:itsm:2.1" match="attributes">
+            <validate schema="itsm.xsd"/>
+        </namespace>
+        <namespace ns="http://www.w3.org/2005/11/its">
+            <validate schema="its.xsd"/>
+        </namespace>
+        <anyNamespace>
+            <allow/>
+        </anyNamespace>
+    </mode>
+    <mode name="attach-all">
+        <anyNamespace>
+            <attach/>
+        </anyNamespace>
+    </mode>    
+</rules>

--- a/NVDL/2.1/xliff_core_2.0.xsd
+++ b/NVDL/2.1/xliff_core_2.0.xsd
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:document:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+
+  <!-- Element Group -->
+
+  <xs:group name="inline">
+    <xs:choice>
+      <xs:element ref="xlf:cp"/>
+      <xs:element ref="xlf:ph"/>
+      <xs:element ref="xlf:pc"/>
+      <xs:element ref="xlf:sc"/>
+      <xs:element ref="xlf:ec"/>
+      <xs:element ref="xlf:mrk"/>
+      <xs:element ref="xlf:sm"/>
+      <xs:element ref="xlf:em"/>
+    </xs:choice>
+  </xs:group>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="yesNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="yesNoFirstNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="firstNo"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="dirValue">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ltr"/>
+      <xs:enumeration value="rtl"/>
+      <xs:enumeration value="auto"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="appliesTo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="source"/>
+      <xs:enumeration value="target"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="userDefinedValue">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\s:]+:[^\s:]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="attrType_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fmt"/>
+      <xs:enumeration value="ui"/>
+      <xs:enumeration value="quote"/>
+      <xs:enumeration value="link"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="typeForMrkValues">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="generic"/>
+      <xs:enumeration value="comment"/>
+      <xs:enumeration value="term"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="attrType_typeForMrk">
+    <xs:union memberTypes="xlf:typeForMrkValues xlf:userDefinedValue"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="priorityValue">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:minInclusive value="1"/>
+      <xs:maxInclusive value="10"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="stateType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="initial"/>
+      <xs:enumeration value="translated"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Structural Elements -->
+
+  <xs:element name="xliff">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:file"/>
+      </xs:sequence>
+      <xs:attribute name="version" use="required"/>
+      <xs:attribute name="srcLang" use="required" type="xs:language"/>
+      <xs:attribute name="trgLang" use="optional" type="xs:language"/>
+      <xs:attribute ref="xml:space" use="optional" default="default"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="file">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:skeleton"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="xlf:unit"/>
+          <xs:element ref="xlf:group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="original" use="optional"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="skeleton">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="group">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xlf:unit"/>
+          <xs:element ref="xlf:group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="optional"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="unit">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:originalData"/>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="xlf:segment"/>
+          <xs:element ref="xlf:ignorable"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="optional"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:attribute name="type" use="optional" type="xlf:userDefinedValue"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="segment">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:target"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="state" use="optional" type="xlf:stateType" default="initial"/>
+      <xs:attribute name="subState" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ignorable">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:target"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="notes">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:note"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="note">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="appliesTo" use="optional" type="xlf:appliesTo"/>
+      <xs:attribute name="category" use="optional"/>
+      <xs:attribute name="priority" use="optional" type="xlf:priorityValue" default="1"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="originalData">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:data"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="data">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="xlf:cp"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute ref="xml:space" use="optional" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="source">
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="target">
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:attribute name="order" use="optional" type="xs:positiveInteger"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inline Elements -->
+
+  <xs:element name="cp">
+    <!-- Code Point -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="hex" use="required" type="xs:hexBinary"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ph">
+    <!-- Placeholder -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pc">
+    <!-- Paired Code -->
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dispEnd" use="optional"/>
+      <xs:attribute name="dispStart" use="optional"/>
+      <xs:attribute name="equivEnd" use="optional"/>
+      <xs:attribute name="equivStart" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRefEnd" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRefStart" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlowsEnd" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subFlowsStart" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sc">
+    <!-- Start Code -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="isolated" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ec">
+    <!-- End Code -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="isolated" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="startRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="mrk">
+    <!-- Annotation Marker -->
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_typeForMrk"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="value" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sm">
+    <!-- Start Annotation Marker -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_typeForMrk"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="value" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em">
+    <!-- End Annotation Marker -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="startRef" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/NVDL/2.1/xliff_core_2.1.sch
+++ b/NVDL/2.1/xliff_core_2.1.sch
@@ -1,0 +1,959 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cs01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Committee Specification 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "23 August &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    <sch:title>Schematron Rules for Advanced Validation of XLIFF &version; Core constraints</sch:title>
+    <!-- Namespace Declarations -->
+    <sch:ns uri="urn:oasis:names:tc:xliff:document:2.0" prefix="xlf"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:matches:2.0" prefix="mtc"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:glossary:2.0" prefix="gls"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:fs:2.0" prefix="fs"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:metadata:2.0" prefix="mda"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:resourcedata:2.0" prefix="res"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:changetracking:2.1" prefix="ctr"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:sizerestriction:2.0" prefix="slr"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:validation:2.0" prefix="val"/>
+    <sch:ns uri="http://www.w3.org/2005/11/its" prefix="its"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:itsm:2.1" prefix="itsm"/>
+    <!-- End of Namespace Declarations -->
+    
+    <!-- Rules for primary keys -->
+    <sch:pattern id="K1">
+        <sch:title>The value [of id] must be unique among all 'file' id attribute values within the enclosing 'xliff' element</sch:title>
+        <sch:rule context="xlf:file">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:file[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'file' elements 
+                within the enclosing 'xliff'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K2">
+        <sch:title>The value [of id] must be unique among all 'group' id attribute values within the enclosing 'file' element</sch:title>
+        <sch:rule context="xlf:group">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/g=',$id)"/>
+            <sch:report diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:file//xlf:group[@id=$id])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'group' elements 
+                within the enclosing 'file'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K3">
+        <sch:title>The value [of id] must be unique among all 'unit' id attribute values within the enclosing 'file' element</sch:title>
+        <sch:rule context="xlf:unit">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:file//xlf:unit[@id=$id])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'unit' elements 
+                within the enclosing 'file'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- K4F (file) and K4GU (group/unit) are distinguished for accurate fragID report -->
+    <sch:pattern id="K4F">
+        <sch:title>The value [of id] must be unique among all 'note' id attribute values within the enclosing 'notes' element</sch:title>
+        <sch:rule context="xlf:note[@id][not(ancestor::xlf:unit)][not(ancestor::xlf:group)]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/n=',$id) "/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.htmll#id"
+                test="following-sibling::xlf:note[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'note' elements 
+                within the enclosing 'notes'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K4GU">
+        <sch:title>The value [of id] must be unique among all 'note' id attribute values within the enclosing 'notes' element</sch:title>
+        <sch:rule context="xlf:note[@id][ancestor::xlf:unit | ancestor::xlf:group]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,concat('/',substring(local-name(../..),1,1),'=',../../@id),'/n=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:note[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'note' elements 
+                within the enclosing 'notes'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- K5C (Core), K5MTC (MTC Module) and K5CTR (CTR Module) are distinguished for accurate fragID report and observing independency of the modules -->
+    <sch:pattern id="K5C">
+        <sch:title>The value [of id] must be unique among all 'data' id attribute values within the enclosing 'originalData' element</sch:title>
+        <sch:rule context="xlf:data[local-name(../..)='unit']">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/d=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:data[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'data' elements 
+                within the enclosing 'originalData'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- K6S (source) and K6T (target) are distinguished for accurate fragID report -->
+    <sch:pattern id="K6S">
+        <sch:title>Except for the above exception [target duplication], the value [of id attribute] must be unique among all of the above 
+            [segment, ignorable, mkr, sm,pc, sc, ec, ph] within the enclosing 'unit' element</sch:title>
+        <sch:rule context="xlf:source[ancestor::xlf:segment| ancestor::xlf:ignorable]//xlf:*[@id]|
+            xlf:segment[@id]| xlf:ignorable[@id]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:unit//xlf:*[@id=$id][ancestor-or-self::xlf:segment| ancestor-or-self::xlf:ignorable][not(ancestor::xlf:target)])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more then once among inline and/or 'segmen'/'ignorable' 
+                elements within the enclosing 'unit'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K6T">
+        <sch:title>The inline elements enclosed by a 'target' element must use the duplicate id values of their corresponding inline elements enclosed within the sibling 'source' element if and only if those corresponding elements exist</sch:title>
+        <sch:rule context="xlf:target[ancestor::xlf:segment | ancestor::xlf:ignorable]//xlf:*[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id,'/u=',$unit-id,'/t=',$id)"/>
+            <sch:let name="counter" value="count(ancestor::xlf:unit//xlf:*[@id=$id]
+                [ancestor-or-self::xlf:segment| ancestor-or-self::xlf:ignorable])"/>
+            <!-- If the counter is 1, then the id is unique and therefore valid -->
+            <!-- If the counter is 2 (duplication exsists), the duplication must be 
+            in the sibling source, have the same name and contain same attributes-->
+            <!-- If the counter is more than 2 or the duplication is not in the right 
+            position, then an error will be reported -->
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="($counter=1) or ($counter=2 and
+                count(ancestor::xlf:segment/xlf:source//xlf:*[@id=$id]
+                [local-name()= local-name(current())]| 
+                ancestor::xlf:ignorable/xlf:source//xlf:*[@id=$id][local-name()= 
+                local-name(current())])=1)">
+                Invalid id used for element '<sch:name/>'. It must duplicate the 
+                id of its corresponding element, enclosed within the 'source' 
+                element or be unique in the scope of 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K7">
+        <sch:title>The value of the order attribute must be unique within the enclosing 'unit' element</sch:title>
+        <sch:rule context="xlf:target[@order][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="order" value="@order"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#order"
+                test="count(ancestor::xlf:unit//xlf:target[ancestor::xlf:segment|ancestor::xlf:ignorable][@order=$order])>1">
+                The value '<sch:value-of select="$order"/>' is used more than once for 'order' attributes of 'target' elements 
+                within the enclosing 'unit'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- End of Rules for primary keys -->
+    
+    <!-- Remaining Rules -->
+    <sch:pattern id="F1">
+        <sch:title>The 'trgLang' attribute is required if and only if the XLIFF Document contains 'target' elements 
+            that are children of 'segment' or 'ignorable'</sch:title>
+        <sch:rule context="xlf:target[parent::xlf:segment | parent::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#xliff" 
+                test="/xlf:xliff/@trgLang">
+                XLIFF document contains 'target' element(s), but the 'trgLang' attribute of 'xliff' is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F2">
+        <sch:title>The attribute 'href' is required if and only if the 'skeleton' element is empty</sch:title>
+        <sch:rule context="xlf:skeleton">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#skeleton"
+                test="not(@href) and not(child::node())">
+                'skeleton' element must not be empty when the 'href' attribute is missing.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#skeleton"
+                test="@href and  child::node()">
+                'skeleton' element must be empty when containing 'href' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F3">
+        <sch:title>A 'unit' must contain at least one 'segment' element</sch:title>
+        <sch:rule context="xlf:unit">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', current()/@id)"/>
+            <sch:report  diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#unit"
+                test="not(child::xlf:segment)">
+                Incomplete 'unit'; it must have at least one 'segment' child.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F4S">
+        <sch:title>When a 'source' element is a child of 'segment' or 'ignorable', the explicit or inherited value
+            of the optional xml:lang must be equal to the value of the srcLang attribute of the enclosing 'xliff' 
+            element</sch:title>
+        <sch:p>This rule does not rais an error if 'xml:lang' is a subcategory of 'srcLang', but not vice versa.
+            i.e. 'srcLang="en"/xml:lang="en-ie"' is a valid pair.</sch:p>
+        <sch:rule context="xlf:source[@xml:lang][parent::xlf:segment | parent::xlf:ignorable]">
+            <sch:let name="srcLang" value="/xlf:xliff/@srcLang"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report  diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#target"
+                test="not(lang($srcLang))">
+                'xml:lang' attribute of the 'source' element and 'srcLang' attribute of the 'xliff' are not matching.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F4T">
+        <sch:title>When a 'target' element is a child of 'segment' or 'ignorable', the explicit or inherited value
+            of the optional xml:lang must be equal to the value of the trgLang attribute of the enclosing 'xliff' 
+            element</sch:title>
+        <sch:p>This rule does not rais an error if 'xml:lang' is a subcategory of 'trgLang', but not vice versa.
+            i.e. 'trgLang="en"/xml:lang="en-ie"' is a valid pair.</sch:p>
+        <sch:rule context="xlf:target[@xml:lang][parent::xlf:segment | parent::xlf:ignorable]">
+            <sch:let name="trgLang" value="/xlf:xliff/@trgLang"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report  diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#target"
+                test="not(lang($trgLang))">
+                'xml:lang' attribute of the 'target' element and 'trgLang' attribute of the 'xliff' are not matching.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5S">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'yes' and appear in 'source'. 
+            An error will be raised if there exists any 'ec' in the same 'unit' and in a 'source', corresponding to this 'sc' by 'startRef'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:source][@isolated='yes'][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="ancestor::xlf:unit//xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+                'isolated' attribute is set to 'yes', but 'ec' element(s) referencing this start code found within the same unit.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5T">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'yes' and appear in 'target'. 
+            An error will be raised if there exists any 'ec' in the same 'unit' and in a 'target', corresponding to this 'sc' by 'startRef'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:target][@isolated='yes'][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/t=', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="ancestor::xlf:unit//xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+                'isolated' attribute is set to 'yes', but 'ec' element(s) referencing this start code found within the same unit.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5.1S">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'no' (or missing) and appear in 'source'. 
+            An error will be raised if
+            a) there is not one and only one 'ec' element in the same 'unit', in a 'source', which appears after the 'sc' 
+            and corresponds to this 'sc' by 'startRef';
+            b) the values of 'canCopy', 'canDelete', 'canReorder' or 'canOverlap' attributes are not matching with the 
+            corresponding ec;
+            c) the value of 'canReorder' is set to 'firstNo', but is not 'no' in the corresponding 'ec'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable][@isolated='no'] | 
+            xlf:sc[ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable][not(@isolated)]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/', $id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="count(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit[@id=$unit-id]][ancestor::xlf:file[@id=$file-id]])=1">
+                'isolated' attribute is set to 'not', but the corresponding 'ec' element within the same 'unit' was not found. 
+                The end code must appear after the start code.
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canCopy='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='no'])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canCopy='yes' or not(@canCopy)) and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canCopy)])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canDelete='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='no'])">
+                'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canDelete='yes' or not(@canDelete)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canDelete)])">
+                'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canReorder='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canReorder='yes' or not(@canReorder)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canReorder)])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canOverlap='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='no'])">
+                'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canOverlap='yes' or not(@canOverlap)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canOverlap)])">
+                'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="@canReorder='firstNo' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' is set to 'firstNo', but the corresponding 'ec', within the same 'unit'
+                has not set its 'canReorder' attribute to 'no'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5.1T">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'no' (or missing) and appear in 'target'. 
+            An error will be raised if
+            a) there is not one and only one 'ec' element in the same 'unit', in a 'target', which appears after the 'sc' 
+            and corresponds to this 'sc' by 'startRef';
+            b) the values of 'canCopy', 'canDelete', 'canReorder' or 'canOverlap' attributes are not matching with the 
+            corresponding ec;
+            c) the value of 'canReorder' is set to 'firstNo', but is not 'no' in the corresponding 'ec'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable][@isolated='no'] | 
+            xlf:sc[ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable][not(@isolated)]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/t=', $id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="count(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit[@id=$unit-id]][ancestor::xlf:file[@id=$file-id]])=1">
+                'isolated' attribute is set to 'not', but the corresponding 'ec' element within the same 'unit' was not found.
+                The end code must appear after the start code.
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canCopy='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='no'])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canCopy='yes' or not(@canCopy)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canCopy)])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canDelete='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='no'])">
+                'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canDelete='yes' or not(@canDelete)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canDelete)])">
+                The 'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canReorder='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canReorder='yes' or not(@canReorder)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canReorder)])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canOverlap='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='no'])">
+                'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canOverlap='yes' or not(@canOverlap)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canOverlap)])">
+                The 'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="@canReorder='firstNo' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' is set to 'firstNo', but the corresponding 'ec', within the same 'unit'
+                has not set its 'canReorder' attribute to 'no'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F6S">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'sc' element corresponding to this
+            end code [ec] is not in the same 'unit' and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'ec' which are in 'source' and raises an error if
+            a) 'id' and 'startRef' attributes are used illegally, based on the value of 'isolated': if 'yes',
+            only 'id' must be used and if 'no' (or missing), only 'startRef' must be specified;
+            b) 'isolated' is 'no' (or missing)) and the 'dir' attribute is used;
+            c)'isolated' is set to 'no', but there is no 'sc' in the same 'unit', in a 'source' and which
+            appears before this end code.
+        </sch:p>
+        <sch:rule context="xlf:ec[ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='yes' and @id and not(@startRef)) or 
+                ((@isolated='no' or not(@isolated)) and @startRef and not(@id))">
+                Illegal use of 'id' and 'startRef' atribute. If 'isolated' is set to 'yes', only 'id' must be 
+                used and if set to 'no' (or missing), only 'startRef' must be specified
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and @dir">
+                The 'dir' attribute may be used only when the attribute 'isolated' is set to 'yes'
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and count(preceding::xlf:sc[@id=current()/@startRef][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]
+                [ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][not(@isolated='yes')])!=1">
+                'isolated' attribute is set to 'not', but the corresponding 'sc' element within the same 'unit' was not found. 
+                The start code must appear befor the end code
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F6T">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'sc' element corresponding to this
+            end code [ec] is not in the same 'unit' and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'ec' which are in 'target' and raises an error if
+            a) 'id' and 'startRef' attributes are used illegally, based on the value of 'isolated': if 'yes',
+            only 'id' must be used and if 'no' (or missing), only 'startRef' must be specified;
+            b)'isolated' is set to 'no' (or missing), but there is no 'sc' in the same 'unit', in a 'target' and which
+            appears before this end code.
+            c) 'isolate' is set to 'no' (or missing) and 'dir' attribute is used. 
+        </sch:p>
+        <sch:rule context="xlf:ec[ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='yes' and @id and not(@startRef)) or 
+                ((@isolated='no' or not(@isolated)) and @startRef and not(@id))">
+                Illegal use of 'id' and 'startRef' atribute. If 'isolated' is set to 'yes', only 'id' must be 
+                used and if set to 'no' (or missing), only 'startRef' must be specified
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and @dir">
+                The 'dir' attribute may be used only when the attribute 'isolated' is set to 'yes'
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and count(preceding::xlf:sc[@id=current()/@startRef][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]
+                [ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][not(@isolated='yes')])!=1">
+                'isolated' attribute is set to 'not', but the corresponding 'sc' element within the same 'unit' was not found. 
+                The start code must appear befor the end code.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F7">
+        <sch:title>If the attribute subState is used, the attribute state must be explicitly set</sch:title>
+        <sch:rule context="xlf:segment[@subState]" >
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id, '/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#substate"
+                test="@state" >
+                'segment' element specifies 'subState' attribute, but missing the 'state' attribute.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F8">
+        <sch:title>If the attribute 'subType' is used, the attribute 'type' must be specified as well</sch:title>
+        <sch:p>This rule select inline elements, which specify 'subType'. It also checks the value of 'subType'.</sch:p>
+        <sch:rule context="xlf:*[@subType][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subtype"
+                test="@type">
+                '<sch:name/>' element specifies 'subType' attribute, but missing the 'type' attribute.
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subtype"
+                test="((@subType='xlf:i' or @subType='xlf:u' or @subType='xlf:lb' or @subType='xlf:pb' or @subType='xlf:b')and( @type='fmt')) or
+                (@subType='xlf:var' and @type='ui') or not(starts-with(@subType,'xlf:'))">
+                'type' and 'subType' attributes don't match. Value of 'type' must either be set to a user-defined value, 
+                or to 'ui' when 'subType=xlf:var', or to 'fmt' for following values of 'subType':'xlf:i','xlf:u','xlf:lb' and 'xlf:pb'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F9">
+        <sch:title>The copyOf attribute must be used when, and only when, the base code has no associated original data</sch:title>
+        <sch:rule context="xlf:*[@copyOf][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="local-name()='pc' and (@dataRefStart or @dataRefEnd)">
+                'pc' cannot use 'copyOf' attribute while referring to the original data through 'dataRefStart/dataRefEnd' attributes.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="local-name()!='pc' and @dataRef">
+                '<sch:name/>' cannot use 'copyOf' attribute while referring to the original data through 'dataRef' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F10">
+        <sch:title>When the attribute canReorder is set to no or firstNo, the attributes canCopy and canDelete must also be set to no</sch:title>
+        <sch:rule context="xlf:*[@canReorder='no'][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:*[@canReorder='firstNo'][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints"
+                test="@canDelete='no' and @canCopy='no'">
+                '<sch:name/>' element has set its 'canReorder' attribute to '<sch:value-of select="@canReorder"/>', but 'canDelete' and 
+                'canCopy' attributes are not set to 'no'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F11S">
+        <sch:title>Translate Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='generic'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:sm[not(@type)][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] |
+            xlf:mrk[@type='generic'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:mrk[not(@type)][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#translateAnnotation"
+                test="@translate" role="warning">
+                '<sch:name/>' element seems to be used for translate annotaition, but missing the 'translate' attribute.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F11T">
+        <sch:title>Translate Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='generic'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]|xlf:sm[not(@type)][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]|
+            xlf:mrk[@type='generic'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:mrk[not(@type)][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#translateAnnotation"
+                test="@translate" role="warning">
+                '<sch:name/>' element seems to be used for translate annotaition, but missing the 'translate' attribute.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F12S">
+        <sch:title>Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]|xlf:mrk[@type='comment'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f', ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="(@value and not(@ref))or(@ref and not(@value))">
+                '<sch:name/>' element must contain one and only one of 'value' and 'ref' attributes when used for comment annotation.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F12T">
+        <sch:title>Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]|xlf:mrk[@type='comment'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="(@value and not(@ref))or(@ref and not(@value))">
+                '<sch:name/>' element cannot contain both 'value' and 'ref' attributes simultaneously when used for comment annotation.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F13S">
+        <sch:title>ref attribute in Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][@ref][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] |
+            xlf:mrk[@type='comment'][@ref][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="count(ancestor::xlf:unit//xlf:note[@id= substring-after($ref,'#n=')])=1">
+                'ref' attribute of '<sch:name/>' must point to a 'note' element within the same unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F13T">
+        <sch:title>ref attribute in Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][@ref][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable] | 
+            xlf:mrk[@type='comment'][@ref][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="count(ancestor::xlf:unit//xlf:note[@id= substring-after($ref,'#n=')])=1">
+                'ref' attribute of '<sch:name/>' must point to a 'note' element within the same unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F14">
+        <sch:title>The 'copyOf' attribute must point to a code within the same 'unit'</sch:title>
+        <sch:rule context="xlf:*[@copyOf][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="copyOf" value="@copyOf"/>
+            <sch:let name="fragid" value="concat(ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="ancestor::xlf:unit//xlf:*[ancestor::xlf:segment | ancestor::xlf:ignorable][@id=$copyOf]">
+                No inline element with 'id=<sch:value-of select="$copyOf"/>' found within the same 'unit' (allowed referencing pattern: copyOf="id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="ancestor::xlf:unit//xlf:*[ancestor::xlf:segment | ancestor::xlf:ignorable][@id=$copyOf][not(@dataRef)][not(@dataRefStart)][not(@dataRefEnd)]">
+                If an inline code has associated original data (referes to a 'data' element), it cannot be replicated.
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="ancestor::xlf:unit//xlf:*[ancestor::xlf:segment | ancestor::xlf:ignorable][@id=$copyOf][@canCopy='no']">
+                The 'canCopy' attribute of the inline element with id='<sch:value-of select="$copyOf"/>' is set to 'no' and therefore cannot be replicated.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F15">
+        <sch:title>dataRef attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:*[@dataRef][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#dataref"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRef]">
+                'dataRef' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRef="data-id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F16S">
+        <sch:title>dataRefEnd attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefEnd][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefend"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefEnd]">
+                'dataRefEnd' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefEnd="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefStart">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F16T">
+        <sch:title>dataRefEnd attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefEnd][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefend"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefEnd]">
+                'dataRefEnd' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefEnd="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefStart">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F17S">
+        <sch:title>dataRefStart attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefStart][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefstart"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefStart]">
+                'dataRefStart' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefStart="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefEnd">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F17T">
+        <sch:title>dataRefStart attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefStart][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefstart"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefStart]">
+                'dataRefStart' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefStart="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefEnd">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F18">
+        <sch:title>Its value [order attribute] is an integer from 1 to N, where N is the sum of the numbers of the 'segment' 
+            and 'ignorable' elements within the given enclosing 'unit' element</sch:title>
+        <sch:rule context="xlf:unit">
+            <sch:let name="maxOrder" value="count(xlf:segment|xlf:ignorable)"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',current()/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#segorder"
+                test="descendant::xlf:target[@order>$maxOrder][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+                Invalid value used for order attribute of 'target' element(s). It must be an integer from 1 to <sch:value-of select="$maxOrder"/>.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F19">
+        <sch:title>To be able to map order differences, the 'target' element has an optional order attribute that indicates its position in the sequence of segments (and inter-segments). Its value is an
+            integer from 1 to N, where N is the sum of the numbers of the 'segment' and 'ignorable' elements within the given enclosing 'unit' element.
+            When Writers set explicit order on 'target' elements, they have to check for conflicts with implicit order, as 'target' elements without explicit
+            order correspond to their sibling 'source' elements</sch:title>
+        <sch:rule context="xlf:target[@order][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="order" value="@order"/>
+            <sch:let name="actual-pos" value="count(../preceding-sibling::xlf:segment| ../preceding-sibling::xlf:ignorable)+1"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#segorder"
+                test="ancestor::xlf:unit//xlf:target[@order=$actual-pos][ancestor::xlf:segment | ancestor::xlf:ignorable]"> 
+                The corresponding 'target' element, 'order' attribute of which must be '<sch:value-of select="$actual-pos"/>', is missing within the enclosing 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:*[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][not(@startRef)]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints"
+                test="(ancestor::xlf:segment/target) and 
+                (not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][local-name()=local-name(current())]))">
+                All inline elements with 'canDelete' attribute set to 'no'must have their corresponding elements in the sibling 'target'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20ec">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:ec[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][@startRef]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints"
+                test="(ancestor::xlf:segment/target) and 
+                (not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]))">
+                All inline elements with 'canDelete' attribute set to 'no'must have their corresponding elements in the sibling 'target'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20W">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:*[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][not(@startRef)]" role="warn">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:segment[not(@state='final')] and ancestor::xlf:segment/xlf:target and 
+                not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][local-name()=local-name(current())])">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target (not an error since 'state' attribute of the containing 'segment' is not 
+                final').
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20W-ig">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:*[@canDelete='no'][ancestor::xlf:ignorable][ancestor::xlf:source][not(@startRef)]" role="warn">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:ignorable/xlf:target and 
+                not(ancestor::xlf:ignorable/xlf:target//xlf:*[@id=$id][local-name()=local-name(current())])">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20Wec">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:ec[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][@startRef]" role="warn">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:segment[not(@state='final')] and ancestor::xlf:segment/xlf:target and 
+                (not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]))">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target (not an error since 'state' attribute of the containing 'segment' is not 
+                final').
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20Wec-ig">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:ec[@canDelete='no'][ancestor::xlf:ignorable][ancestor::xlf:source][@startRef]" role="warn">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:ignorable/xlf:target and 
+                (not(ancestor::xlf:ignorable/xlf:target//xlf:ec[@startRef=$id]))">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target.
+                final').
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F21">
+        <sch:title>subFlows must point to units within the same file</sch:title>
+        <sch:rule context="xlf:*[@subFlows][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:let name="sub-flows" value=" normalize-space(@subFlows)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFlows" 
+                test="count(tokenize($sub-flows,' '))=count(ancestor::xlf:file//xlf:unit[@id=tokenize($sub-flows,' ')])">
+                The 'subFlows' attribute must contain a space-seperated list of 'unit' identifiers within the same 'file'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F22">
+        <sch:title>subFlowsEnd must point to units within the same file</sch:title>
+        <sch:rule context="xlf:pc[@subFlowsEnd][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:let name="sub-flows" value=" normalize-space(@subFlowsEnd)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFlows" 
+                test="count(tokenize($sub-flows,' '))=count(ancestor::xlf:file//xlf:unit[@id=tokenize($sub-flows,' ')])">
+                The 'subFlowsEnd' attribute must contain a space-seperated list of 'unit' identifiers within the same 'file'.
+            </sch:assert>
+            <sch:assert test="@subFlowsStart">
+                'subFlowsStart' and 'subFlowsEnd' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F23">
+        <sch:title>subFlowsStart must point to units within the same file</sch:title>
+        <sch:rule context="xlf:pc[@subFlowsStart][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:let name="sub-flows" value=" normalize-space(@subFlowsStart)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFlows" 
+                test="count(tokenize($sub-flows,' '))=count(ancestor::xlf:file//xlf:unit[@id=tokenize($sub-flows,' ')])">
+                The 'subFlowsStart' attribute must contain a space-seperated list of 'unit' identifiers within the same 'file'.
+            </sch:assert>
+            <sch:assert test="@subFlowsEnd">
+                'subFlowsStart' and 'subFlowsEnd' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F24">
+        <sch:title>Translation Candidate Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='mtc:match'][ancestor::xlf:segment|ancestor::xlf:ignorable] | xlf:mrk[@type='mtc:match'][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:report test="@ref">
+                'ref' attribute is not allowed in Translation Candidate Annotation, when the 'type' attribute is set to 'mtc:match'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F25">
+        <sch:rule context="xlf:cp">
+            <sch:let name="hex" value="current()/@hex"/>
+            <!--<sch:assert test="matches(@hex,'^([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]|[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]|[01][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])$')">
+                The value of 'hex' attribute must be in  the hexadecimal inclusive range of 0000 to 10FFFF. 
+            </sch:assert>-->
+            <sch:assert test="matches($hex,'^000[0-8]$') or matches($hex,'^000B|000b$') or matches($hex,'^000C|000c$') or matches($hex,'^000[EeFf]|001[0-9a-fA-F]$')
+                or matches($hex,'^007[Ff]|008[0-4]$') or matches($hex,'^008[6-9a-fA-F]|009[0-9a-fA-F]$') or matches($hex,'^[Dd][8-9a-fA-F][0-9a-fA-F][0-9a-fA-F]$') ">
+                The value of 'hex' attribute must be an illegal XML value.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F26">
+        <sch:rule context="xlf:pc[@equivStart] | xlf:pc[@equivEnd]">
+            <sch:assert test="@equivStart and @equivEnd">
+                The pair of 'equivStart'/'equivEnd' attributes must be specified together.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F27">
+        <sch:rule context="xlf:sm">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:assert test="count(following::xlf:em[@startRef=$id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id])!=0">
+                There must be an 'em' element corresponding to this start marker by the 'startRef' attribute (the end marker must appear in the same 'unit' and after the start code).
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F28">
+        <sch:rule context="xlf:em">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:assert test="count(preceding::xlf:sm[@id=$id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id])!=0">
+                There must be an 'sm' element corresponding to this end marker by the 'id' attribute (the start marker must appear in the same 'unit' and before the end code).
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F29">
+        <sch:rule context="xlf:segment[@state='translated' or @state='reviewed' or @state='final']">
+            <sch:assert test="child::xlf:target">
+                Incorrect usage of 'state' attribute; when it is set to 'translated', 'reviewed' or 'final', the 'segment' must contain 'target' child. 
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F30S">
+        <sch:rule context="xlf:*[@canReorder='no'][ancestor::xlf:source]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:report test="(ancestor::xlf:pc and ((preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes' or not(@canReorder)]) or parent::xlf:pc[@canReorder='yes' or not(@canReorder)])) or
+                (not(ancestor::xlf:pc) and preceding::xlf:*[position()=1][ancestor::xlf:source][local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes' or not(@canReorder)])">
+                Invalid non-reorderable sequence; inline element with 'canReorder' set to 'no' must not be preceded with inline element with 'canReorder' set to 'yes' or missing
+            </sch:report>
+            <sch:assert test="(not(ancestor::xlf:pc) and count(preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:source])!=0) or
+                (ancestor::xlf:pc and count(ancestor::xlf:pc[@canReorder='firstNo'] | preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:source])!=0)">
+                Invalid non-reorderable sequence; missing the start element with 'canReorder' set to 'firstNo' within the same 'unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F30T">
+        <sch:rule context="xlf:*[@canReorder='no'][ancestor::xlf:target]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:report test="(ancestor::xlf:pc and ((preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes'or not(@canReorder)]) or parent::xlf:pc[@canReorder='yes' or not(@canReorder)])) or
+                (not(ancestor::xlf:pc) and preceding::xlf:*[position()=1][ancestor::xlf:target][local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes' or not(@canReorder)])">
+                Invalid non-reorderable sequence; inline element with 'canReorder' set to 'no' must not be preceded with inline element with 'canReorder' set to 'yes' or missing
+            </sch:report>
+            <sch:assert test="(not(ancestor::xlf:pc) and count(preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:target])!=0) or
+                (ancestor::xlf:pc and count(ancestor::xlf:pc[@canReorder='firstNo'] | preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:source])!=0)">
+                Invalid non-reorderable sequence; missing the start element with 'canReorder' set to 'firstNo' within the same 'unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F31">
+        <sch:rule context="xlf:*[@id][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id][1]]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:*[1]/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id]/preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id=$preceding-id][1])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:*[@id][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:ec[@startRef][1]]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:ec[1]/@startRef"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id]/preceding-sibling::xlf:ec[1][@startRef=$preceding-id])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:*[@id][@canReorder='no'][ancestor::xlf:source][parent::xlf:pc][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="parent-id" value="parent::xlf:pc/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]/parent::xlf:pc[@id=$parent-id])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F31ec">
+        <sch:rule context="xlf:ec[@startRef][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id][1]]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:*[1]/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]/preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id=$preceding-id][1])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:ec[@startRef][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:ec[@startRef][1]]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:ec[1]/@startRef"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]/preceding-sibling::xlf:ec[@startRef=$preceding-id][1])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:ec[@startRef][@canReorder='no'][ancestor::xlf:source][parent::xlf:pc][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="parent-id" value="parent::xlf:pc/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]/parent::xlf:pc[@id=$parent-id])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- End of Schematron Rules -->
+    <!-- Diagnostics used to provide fragment identification notations in accordance with sec. 3 of XLIFF Specification -->
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/fs.sch
+++ b/sch/2.1/fs.sch
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Format Style module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="fs" uri="urn:oasis:names:tc:xliff:fs:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    
+    <sch:pattern id="fs1">
+        <sch:rule context="xlf:ec[@fs:fs]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#fs"
+                test="current()/@isolate='yes'">
+                The fs:fs attribute is used, but the isolated attribute is not set to 'yes'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="fs2">
+        <sch:rule context="xlf:ec[@fs:subFs]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFs"
+                test="current()/@isolated='yes'">
+                The fs:subFs attribute is used, but the isolated attribute is not set to 'yes'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="fs3">
+        <sch:rule context="xlf:*[@fs:subFs]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFs"
+                test="current()/@fs:fs">
+               The fs:subFs attribute is used, but fs:fs is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    
+    
+  
+        <sch:diagnostics>
+            <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+        </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/glossary.sch
+++ b/sch/2.1/glossary.sch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2' >
+    <sch:title>Schematron rules for checking the constraints of the Glossary module against XLIFF Vesrion &version; spec</sch:title>
+    <sch:ns prefix="gls" uri="urn:oasis:names:tc:xliff:glossary:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>    
+    <sch:pattern id="gls1">
+        <sch:rule context="gls:glossEntry[@id] | gls:translation[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#gls_id"
+                test="count(ancestor::gls:glossary//gls:glossEntry[@id=$id] | ancestor::gls:glossary//gls:translation[@id=$id])>1">
+                id duplication found among 'gls:glossEntry' and/or 'gls:translation' elements within the Glossary Module.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="gls2">
+        <sch:rule context="gls:glossEntry">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#glossentry" 
+                test="child::gls:translation or child::gls:definition">
+                Incomplete 'gls:glossEntry' element.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="gls3">
+        <sch:rule context="gls:glossEntry[@ref] | gls:translation[@ref]">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#gls_ref"
+                test="(not(contains($ref,'#')) and ancestor::xlf:unit//xlf:*[@id=$ref][ancestor-or-self::xlf:segment]) or 
+                (contains($ref,'#') and ancestor::xlf:unit//xlf:*[@id=substring-after($ref,'#')][ancestor-or-self::xlf:segment])">
+                'ref' attribute must point to a span of text within the same 'unit' (allowed referencing patterns: ref="#id" or ref="id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/its.sch
+++ b/sch/2.1/its.sch
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+
+<sch:schema   
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    xmlns:mtc="urn:oasis:names:tc:xliff:matches:2.0"
+    xmlns:ctr="urn:oasis:names:tc:xliff:changetracking:2.1"
+	xmlns:res="urn:oasis:names:tc:xliff:resourcedata:2.0"
+	xmlns:its="http://www.w3.org/2005/11/its"
+	xmlns:itsm="urn:oasis:names:tc:xliff:itsm:2.1"
+    queryBinding='xslt2' 
+    schemaVersion='ISO19757-3'>
+    <sch:title>Schematron rules for checking the constraints of the ITS module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="its" uri="http://www.w3.org/2005/11/its"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    <!-- ctr removed not part of 2.1 release -->
+    <sch:ns prefix="itsm" uri="urn:oasis:names:tc:xliff:itsm:2.1"/>
+    <sch:ns prefix="mtc" uri="urn:oasis:names:tc:xliff:matches:2.0"/>
+    
+    <!-- ITS rules for mapping ITS data categories used in XLIFF 2.x. The rules are to be consumed by an ITS 2.0 conformant processor. The rules are ordered following the data category sub sections of the ITS module section in the XLIFF 2.1 specification.-->
+    
+    <its:rules version="2.0" queryLanguage="xpath">
+        
+        <!-- Rules for Allowed Characters are not needed, but covered by the W3C ITS namespace. -->
+        
+        <!-- Rules for Domain -->
+        <its:domainRule selector="//xlf:*[@itsm:domains]" domainPointer="@itsm:domains"/>
+        
+        <!-- Rules for Localization Quality Issue are not needed, but covered by the W3C ITS namespace. --> 
+        
+        <!-- Rules for Localization Quality Rating are not needed, but covered by the W3C ITS namespace. -->
+        
+        <!-- Rules for Text Analysis are not needed, but covered by the W3C ITS namespace. -->
+        
+        <!-- Rules for Localization Note. These rules cover the following cases:
+            
+        1) Note at file, no appliesTo attribute set: note relates to complete content of the file.
+        2) Note at group, no appliesTo attribute set: Note relates to complete content of the group.
+        3) Note at unit, appliesTo=target: note relates to target elements in unit. 
+        4) Note at file, appliesTo=target: note relates to target elements in file.
+        5) Note at group, appliesTo=target: note relates to target elements in group.
+        6) Note at unit, appliesTo=source: note relates to source elements in unit. 
+        7) Note at file, appliesTo=source: note relates to source elements in file.
+        8) Note at group, appliesTo=source: note relates to source elements in group.
+        
+        9) Annotation of the type="comment" with the Localization Note in the value attribute
+        
+        10) Note at unit without an appliesTo attribute cannot be properly parsed by a generic ITS Processor, as it can either apply to the whole unit content or else be referenced from an inline span by a comment annotation, hence these scenarios are not covered by the rules and the overlap of this data category with XLIFF features is considered partial.
+                
+        A priority attribute can appear on XLIFF <note>, it can be an integer 1-10. Value "1" means ITS alert and any other number ITS description.
+        -->
+        
+        <!-- Start of notes of type "alert" -->
+        <!-- 1) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source | //xlf:file/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]"
+            
+            locNoteType="alert"/>
+        <!-- 2) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source | //xlf:group/xlf:notes/xlf:note[not(@appliesTo)][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[not(@appliesTo) and not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 3) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]"
+            
+            locNoteType="alert"/>
+        <!-- 4) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target" 
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 5) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 6) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 7) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        <!-- 8) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][not(@priority) or @priority=1]" 
+            
+            locNoteType="alert"/>
+        
+        
+        <!-- Start of notes of type "description" -->
+        <!-- 9 -->
+        <its:locNoteRule selector="//xlf:*[@type='comment' and @value]" locNotePointer="@value" locNoteType="description"/>
+        
+        
+        
+        
+        <!-- 1) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source | //xlf:file/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]" locNoteType="description"/>
+        <!-- 2) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source | //xlf:group/xlf:notes/xlf:note[not(@appliesTo)][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[not(@appliesTo) and not(@priority) or @priority=1]" 
+            
+            locNoteType="description"/>
+        <!-- 3) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]"
+            
+            locNoteType="description"/>
+        <!-- 4) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target" 
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 5) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:target"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='target'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 6) -->
+        <its:locNoteRule selector="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:unit/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 7) -->
+        <its:locNoteRule selector="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:file/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>
+        <!-- 8) -->
+        <its:locNoteRule selector="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]/../..//xlf:segment/xlf:source"
+            
+            locNotePointer="//xlf:group/xlf:notes/xlf:note[@appliesTo='source'][@priority>1 and @priority&lt;=10]" 
+            
+            locNoteType="description"/>        
+        
+        
+        <!-- Rules for Preserve Space: cannot be written since there are not pointer attributes for Preserve Space. But this limitation is OK since a processor can work with this data category locally.-->
+        
+        <!-- Rules for Translate -->
+        <its:translateRule selector="//xlf:*[@translate='no']" translate='no'/>
+        <its:translateRule selector="//xlf:*[@translate='yes']" translate='yes'/>
+        
+        <!-- Rules for External Resource -->
+        <its:externalResourceRefRule selector="//res:source | //res:target" externalResourceRefPointer="@href"/>
+        
+        <!-- Rules for Language Information -->
+        <its:langRule selector="//xlf:*[@xml:lang]" langPointer="@xml:lang"/>
+        <its:langRule selector="//xlf:*[@itsm:lang]" langPointer="@itsm:lang"/>
+        <its:langRule selector="//xlf:source[not(@xml:lang)]" langPointer="ancestor::*/@srcLang"/>
+        <its:langRule selector="//xlf:target[not(@xml:lang)]" langPointer="ancestor::*/@trgLang"/>
+        
+        <!-- Rules for MT Confidence: cannot be written since there is not pointer attribute for MT Confidence. But this limitation is OK since a processor can work with this data category locally. -->
+        
+        <!-- Rules for Provenance: cannot be written since there are no pointer attributes for the provenance records written in  XLIFF. But this limitation is OK since a processor can work with this data category locally. -->
+        
+        <!-- Rules for Terminology -->
+                
+        <its:termRule selector="//xlf:*[@type='term' or @type='its:term-no']"/>
+        <its:termRule selector="//xlf:*[@type='term' or @type='its:term-no'][@ref]" termInfoRefPointer="@ref"/>
+        <its:termRule selector="//xlf:*[@type='term' or @type='its:term-no'][@value]" termInfoPointer="@value"/>
+        
+        
+        
+        <!-- Rules for Directionality: This data category is not mapped to XLIFF 2.X -->
+        
+        <!-- Rules for Elements Within Text: This data category is not represented as metadata in XLIFF 2.X -->
+        
+        <!-- Rules for ID Value: This data category is not represented as metadata in XLIFF 2.X -->
+        
+        <!-- Rules for Locale Filter: cannot be written since there are no pointer attributes for locale filter written in  XLIFF. But this limitation is OK since a processor can work with this data category locally. -->
+        
+        <!-- Rules for Target Pointer -->
+        <its:targetPointerRule selector="//xlf:source" targetPointer="../xlf:target"/>
+        
+        <!-- Rules for storage size: The data category is not covered by the XLIFF 2.1 specification, so no rule is provided. -->
+        
+    </its:rules>
+    <!-- End of ITS Rules -->
+    <!-- Removed CTR -->
+    <!--<sch:pattern>
+        <sch:rule context="ctr:revision">
+            <sch:report test="@its:*[not(name()='its:toolRef')][not(name()='its:tool')][not(name()='its:revToolRef')][not(name()='its:revTool')]
+                [not(name()='its:revPersonRef')][not(name()='its:revPerson')][not(name()='its:revOrgRef')][not(name()='its:revOrg')]
+                [not(name()='its:org')][not(name()='its:provenanceRecordsRef')][not(name()='its:personRef')][not(name()='its:person')]
+                [not(name()='its:orgRef')][not(name()='its:annotatorsRef')]">
+                Invalid 'itsm' attribute used in 'revision'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>-->
+    <sch:pattern>
+        <sch:rule context="*[@its:*]| *[@itsm:*]">
+            <sch:assert test="ancestor-or-self::xlf:xliff/@its:version | ancestor-or-self::xlf:file/@its:version | 
+                            ancestor-or-self::xlf:unit/@its:version | ancestor-or-self::xlf:group/@version | ancestor-or-self::xlf:mrk/@its:version |
+                            ancestor-or-self::xlf:sm/@its:version | ancestor-or-self::mtc:match/@its:version | 
+                            ancestor-or-self::its:locQualityIssues/@its:version | ancestor-or-self::its:provenanceRecord/@its:version | 
+                            ancestor-or-self::its:provenanceRecords/@its:version">
+                ITS version is not bounded in the scope of ITS markup.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:annotatorsRef] | xlf:sm[@its:annotatorsRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:annotatorsRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssuesRef] | xlf:sm[@its:locQualityIssuesRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When used in ITS Localization Quality Issue Annotation, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+            <sch:report test="@its:locQualityIssueType or @its:locQualityIssueComment">
+                When the 'its:locQualityIssuesRef' attribute is used, the following attributes must be declared: 'its:locQualityIssueType' and 'its:locQualityIssueComment'.
+            </sch:report>
+            <sch:report test="@its:locQualityIssueSeverity or @its:locQualityIssueProfileRef or @its:locQualityIssueEnabled">
+                When the 'its:locQualityIssuesRef' attribute is used, the following attributes must be declared: 'its:locQualityIssueSeverity', 'its:locQualityIssueProfileRef' and 'its:locQualityIssueEnabled'..
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssueSeverity] | xlf:mrk[@its:locQualityIssueProfileRef] | 
+            xlf:sm[@its:locQualityIssueSeverity] | xlf:sm[@its:locQualityIssueProfileRef]">
+            <sch:report test="@its:locQualityIssuesRef">
+                When the 'its:locQualityIssueSeverity' or 'its:locQualityIssueProfileRef' attributes are used, the 'its:locQualityIssuesRef' must not be declared.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityRatingScore] | xlf:sm[@its:locQualityRatingScore]">
+            <sch:report test="@its:locQualityRatingVote">
+                When the 'its:locQualityRatingScore' attribute is used, the 'itms:locQualityRatingVote' attribute is not allowed.
+            </sch:report>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:locQualityRatingScore' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityRatingVote] | xlf:sm[@its:locQualityRatingVote]">
+            <sch:report test="@its:locQualityRatingScore">
+                When the 'its:locQualityRatingVote' attribute is used, the 'itms:locQualityRatingScore' attribute is not allowed.
+            </sch:report>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:locQualityRatingVote' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:locQualityRatingScoreThreshold]">
+            <sch:assert test="@its:locQualityRatingScore or ancestor::xlf:*[@its:locQualityRatingScore]">
+                The 'its:locQualityRatingScoreThreshold' attribute may be set only if 'its:locQualityRatingScore' is declared or inherited from upper levels.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:locQualityRatingVoteThreshold]">
+            <sch:assert test="@its:locQualityRatingVote or ancestor::xlf:*[@its:locQualityRatingVote]">
+                The 'its:locQualityRatingVoteThreshold' attribute may be set only if 'its:locQualityRatingVote' is declared or inherited from upper levels.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:taIdentRef] | xlf:sm[@its:taIdentRef]">
+            <sch:report test="@its:taSource or @its:taIdent">
+                When the 'its:taIdentRef' attribute is used, the following attributes are not allowed: 'its:taSource' and 'its:taIdent'.
+            </sch:report>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:taIdentRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:taSource] | xlf:sm[@its:taSource] |
+            xlf:mrk[@its:taIdent] | xlf:sm[@its:taIdent]">
+            <sch:report test="@its:taIdentRef">
+                When the 'its:taSource' or 'its:taIdent' attributes are used, the 'its:taIdentRef' attribute is not allowed.
+            </sch:report>
+            <sch:assert test="@its:taSource and @its:taIdent">
+                The pair of 'its:taSource' and 'its:taIdent'attributes must be present at the same time.
+            </sch:assert>
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:taSource' and 'its:taIdent' attributes are used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:taClassRef] | xlf:sm[@its:taClassRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:taClassRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:lang] | xlf:sm[@its:lang]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:lang' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:mtConfidence] | xlf:sm[@its:mtConfidence]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:mtConfidence' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:provenanceRecordsRef] | xlf:sm[@its:provenanceRecordsRef]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:provenanceRecordsRef' attribute is used, the optional 'type' attribute must be set to 'its:generic' if declared.
+            </sch:assert>
+            <sch:report test="@its:org or @its:orgRef or @its:person or 
+                @its:personRef or @its:revOrg or @its:revOrgRef or 
+                @its:revPerson or @its:revPersonRef or @its:revTool or
+                @its:revToolRef or @its:tool or @its:toolRef">
+                When the 'its:provenanceRecordsRef' attribute is used, the following attributes are not allowed: its:org, its:orgRef, its:person, its:personRef, its:revOrg,
+                its:revOrgRef, its:revPerson, its:revPersonRef, its:revTool, its:revToolRef, its:tool and its:toolRef.
+                
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:allowedCharacters] | xlf:mrk[@itsm:domains] | xlf:mrk[@itsm:lang] | xlf:mrk[@its:localeFilterList] |
+            xlf:sm[@its:allowedCharacters] | xlf:sm[@itsm:domains] | xlf:sm[@itsm:lang] | xlf:sm[@its:localeFilterList]">
+            <sch:assert test="not(@type) or @type='its:generic'">
+                When the 'its:allowedCharacters', 'itsm:domains' or 'its:localeFilterList attributes are used, the value of optional 'type' attribute must be set to 'its:generic'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssuesRef] | xlf:sm[@its:locQualityIssuesRef]">
+            <sch:report test="@its:locQualityIssueSeverity or @its:locQualityIssueProfileRef or @its:locQualityIssueEnabled">
+                If the 'its:locQualityIssuesRef' attribute is declared, the following attributes are not allowd: its:locQualityIssueSeverity, its:locQualityIssueProfileRef, and its:locQualityIssueEnabled".
+            </sch:report>
+            <sch:assert test="count(ancestor::xlf:unit//its:locQualityIssues[@xml:id=substring-after(current()/@its:locQualityIssuesRef , '#its=')])=1">
+                The value of the locQualityIssuesRef attribute must be relative URI (starting with "#its="), and the value after "#its=" must be one of the id attributes declared on a &lt;locQualityIssues> elements within the same 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssuesRef] | xlf:sm[@its:locQualityIssuesRef]">
+            <sch:report test="@its:locQualityIssueType or @its:locQualityIssueComment">
+                When 'its:locQualityIssuesRef' is declared, 'its:locQualityIssueType' and its:locQualityIssueComment are not allowed.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:mrk[@its:locQualityIssueType] | xlf:mrk[@its:locQualityIssueComment] |
+                           xlf:sm[@its:locQualityIssueType] | xlf:sm[@its:locQualityIssueComment] ">
+            <sch:report test="@its:locQualityIssuesRef">
+                When 'its:locQualityIssueType' or 'its:locQualityIssueComment' are declared, 'its:locQualityIssuesRef' is not allowed.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+   <sch:pattern>
+        <sch:rule context="xlf:*[@its:annotatorsRef][not(contains(@its:annotatorsRef, ' '))]">
+            <sch:let name="ref" value="@its:annotatorsRef"/>
+            <sch:let name="its-dc-id" value="substring-before($ref,'|')"/>
+            <sch:report test="$its-dc-id!='allowed-characters' and $its-dc-id!='directionality' and $its-dc-id!='domain' and $its-dc-id!='elements-within-text' and
+                $its-dc-id!='external-resource' and $its-dc-id!='id-value' and $its-dc-id!='language-information' and
+                $its-dc-id!='locale-filter' and $its-dc-id!='localization-note' and $its-dc-id!='localization-quality-issue' and
+                $its-dc-id!='localization-quality-rating' and $its-dc-id!='mt-confidence' and $its-dc-id!='preserve-space' and
+                $its-dc-id!='provenance' and $its-dc-id!='storage-size' and $its-dc-id!='target-pointer' and
+                $its-dc-id!='terminology' and $its-dc-id!='text-analysis' and $its-dc-id!='translate'">
+                Invalid id used for the ITS datacategory <sch:value-of select="$its-dc-id"/>. Please see the Specification for guidelines on the value of this attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:annotatorsRef][(contains(@its:annotatorsRef, ' '))]">
+            <sch:let name="ids-string" value=" replace(@its:annotatorsRef, '\s+',' ')"/>
+            <sch:report  test="contains(substring-after($ids-string,'allowed-characters'),'allowed-characters')  or 
+                contains(substring-after($ids-string,'directionality'),'directionality') or 
+                contains(substring-after($ids-string,'domain'),'domain') or
+                contains(substring-after($ids-string,'elements-within-text'),'elements-within-text') or 
+                contains(substring-after($ids-string,'external-resource'),'external-resource') or
+                contains(substring-after($ids-string,'id-value'),'id-value') or 
+                contains(substring-after($ids-string,'language-information'),'language-information') or 
+                contains(substring-after($ids-string,'locale-filter'),'locale-filter') or 
+                contains(substring-after($ids-string,'localization-note'),'localization-note') or 
+                contains(substring-after($ids-string,'localization-quality-issue'),'localization-quality-issue') or 
+                contains(substring-after($ids-string,'localization-quality-rating'),'localization-quality-rating') or 
+                contains(substring-after($ids-string,'mt-confidence'),'mt-confidence') or 
+                contains(substring-after($ids-string,'preserve-space'),'preserve-space') or 
+                contains(substring-after($ids-string,'provenance'),'provenance') or 
+                contains(substring-after($ids-string,'storage-size'),'storage-size') or 
+                contains(substring-after($ids-string,'target-pointer'),'target-pointer') or 
+                contains(substring-after($ids-string,'terminology'),'terminology') or 
+                contains(substring-after($ids-string,'text-analysis'),'text-analysis') or 
+                contains(substring-after($ids-string,'translate'),'translate')"> 
+                Each ITS data category identifier must not be used more than once.
+            </sch:report>
+            <sch:report test="string-length(replace(replace(current()/@its:annotatorsRef,'\|[^\s]+\s*',''), 'allowed-characters|directionality|domain|elements-within-text|external-resource|id-value|language-information|locale-filter|localization-note|localization-quality-issue|localization-quality-rating|mt-confidence|preserve-space|provenance|storage-size|target-pointer|terminology|text-analysis|translate',''))!=0">
+                'annotatorsRef' contains illegal value for ITS datacategories.
+            </sch:report>
+         </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:annotatorsRef]">
+            <sch:report  test="matches(@its:annotatorsRef,'\|\s+') or matches(@its:annotatorsRef,'\s+\|')"> 
+                The vertical bar in @its:annotatorsRef must not be surrounded by whitespace.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:locQualityIssue">
+            <sch:assert test="@locQualityIssueType or @locQualityIssueComment">
+                At least one of the attributes locQualityIssueType or locQualityIssueComment must be set.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:provenanceRecord">
+            <sch:assert test="@org or @orgRef or @person or 
+                @personRef or @revOrg or @revOrgRef or 
+                @revPerson or @revPersonRef or @revTool or
+                @revToolRef or @tool or @toolRef">
+                At least one of the followings must be set: its:org, its:orgRef, its:person, its:personRef, its:revOrg,
+                its:revOrgRef, its:revPerson, its:revPersonRef, its:revTool, its:revToolRef, its:tool and its:toolRef.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:locQualityIssues | its:provenanceRecords[ancestor::xlf:unit]">
+            <sch:let name="id" value="@xml:id"/>
+            <sch:let name="counter" value="count(ancestor::xlf:unit//its:locQualityIssues[@xml:id=$id] | ancestor::xlf:unit//its:provenanceRecords[@xml:id=$id])"/>
+            <sch:assert test="$counter=1">
+                Value of 'id' must be unique among all of  &lt;locQualityIssues> and &lt;provenanceRecords> elements within the enclosing 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:provenanceRecords[ancestor::xlf:group][not(ancestor::xlf:unit)]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="counter" value="count(ancestor::xlf:group[1]//its:provenanceRecords[@id=$id][not(ancestor::xlf:unit)])"/>
+            <sch:assert test="$counter=1">
+                Value of 'id' must be unique among all of  &lt;provenanceRecords> elements within the enclosing 'group'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="its:provenanceRecords[ancestor::xlf:file][not(ancestor::xlf:unit)][not(ancestor::xlf:group)]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="counter" value="count(ancestor::xlf:file//its:provenanceRecords[@id=$id][not(ancestor::xlf:group)][not(ancestor::xlf:unit)])"/>
+            <sch:assert test="$counter=1">
+                Value of 'id' must be unique among all of  &lt;provenanceRecords> elements within the enclosing 'file'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="xlf:*[@its:locQualityIssuesRef]">
+            <sch:assert test="not(@its:locQualityIssueSeverity)">
+                If 'its:locQualityIssuesRef' attribute is declared, the 'its:locQualityIssueSeverity' must not be used. 
+            </sch:assert>
+            <sch:assert test="not (@its:locQualityIssueProfileRef) ">
+                If 'its:locQualityIssuesRef' attribute is declared, the 'its:locQualityIssueProfileRef' must not be used. 
+            </sch:assert>
+            <sch:assert test="not(@its:locQualityIssueEnabled)">
+                If 'its:locQualityIssuesRef' attribute is declared, the 'its:locQualityIssueEnabled' must not be used. 
+            </sch:assert>
+        </sch:rule>        
+    </sch:pattern>
+</sch:schema>

--- a/sch/2.1/matches.sch
+++ b/sch/2.1/matches.sch
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Translation Candidate Annotation module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="mtc" uri="urn:oasis:names:tc:xliff:matches:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/> 
+    <sch:pattern id="K5MTC">
+        <sch:title>The value [of id] must be unique among all 'data' id attribute values within the enclosing 'originalData' element</sch:title>
+        <sch:rule context="xlf:data[ancestor::mtc:matches]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:data[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'data' elements 
+                within the enclosing 'originalData' in the MTC module.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K6MTC-S">
+        <sch:title>Except for the above exception [target duplication], the value [of id attribute] must be unique among all of the above 
+            [segment, ignorable, mkr, sm,pc, sc, ec, ph] within the enclosing 'revision' element</sch:title>
+        <sch:rule context="xlf:source[ancestor::mtc:match]//xlf:*[@id]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:report see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:source//xlf:*[@id=$id])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more then once among inline and/or 'segmen'/'ignorable' 
+                elements within the enclosing 'revision'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K6MTC-T">
+        <sch:title>The inline elements enclosed by a 'target' element must use the duplicate id values of their corresponding inline elements enclosed within the sibling 'source' element if and only if those corresponding elements exist</sch:title>
+        <sch:rule context="xlf:target[ancestor::mtc:match]//xlf:*[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="counter" value="count(ancestor::mtc:match//xlf:*[@id=$id])"/>
+            <!-- If the counter is 1, then the id is unique and therefore valid -->
+            <!-- If the counter is 2 (duplication exsists), the duplication must be 
+            in the sibling source, have the same name and contain same attributes-->
+            <!-- If the counter is more than 2 or the duplication is not in the right 
+            position, then an error will be reported -->
+            <sch:assert see="&this-loc;/&name;-&stage;.html#id"
+                test="($counter=1) or ($counter=2 and
+                count(ancestor::mtc:match//xlf:source//xlf:*[@id=$id]
+                [local-name()= local-name(current())])=1)">
+                Invalid id used for element '<sch:name/>'. It must duplicate the 
+                id of its corresponding element, enclosed within the 'source' 
+                element or be unique in the scope of 'revision'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc-F15">
+        <sch:title>dataRef attribute must point to a data element within the same mtc:match</sch:title>
+        <sch:rule context="xlf:*[@dataRef][ancestor::mtc:match]">
+            <sch:assert test="ancestor::mtc:match/xlf:originalData/xlf:data[@id=current()/@dataRef]">
+                'dataRef' attribute must point to a 'data' element within the same 'mtc:match' (allowed referencing pattern: dataRef="data-id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc-F16">
+        <sch:title>dataRefEnd attribute must point to a data element within the same mtc:match</sch:title>
+        <sch:rule context="xlf:pc[@dataRefEnd][ancestor::mtc:match]">
+            <sch:assert test="ancestor::mtc:match/xlf:originalData/xlf:data[@id=current()/@dataRefEnd]">
+                'dataRefEnd' attribute must point to a 'data' element within the same 'mtc:match' (allowed referencing pattern: dataRefEnd="data-id").
+            </sch:assert>
+            <sch:assert test="@dataRefStart">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc-F17">
+        <sch:title>dataRefStart attribute must point to a data element within the same mtc:match</sch:title>
+        <sch:rule context="xlf:pc[@dataRefStart][ancestor::mtc:match]">
+            <sch:assert test="ancestor::mtc:match/xlf:originalData/xlf:data[@id=current()/@dataRefStart]">
+                'dataRefStart' attribute must point to a 'data' element within the same 'mtc:match' (allowed referencing pattern: dataRefStart="data-id").
+            </sch:assert>
+            <sch:assert test="@dataRefEnd">
+                'dataRefStart' and 'dataRefEnd' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc1">
+        <sch:rule context="mtc:match[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#candidates_id"
+                test="following-sibling::mtc:match[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'match' elements within the enclosing 'matches' element.
+            </sch:report>
+        </sch:rule>        
+    </sch:pattern>
+    <sch:pattern id="mtc2">
+        <sch:rule context="mtc:match">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#candidates_ref"
+                test="(not(contains($ref,'#')) and ancestor::xlf:unit//xlf:*[@id=$ref][ancestor-or-self::xlf:segment]) or 
+                (contains($ref,'#') and ancestor::xlf:unit//xlf:*[@id=substring-after($ref,'#')][ancestor-or-self::xlf:segment])">
+                'ref' attribute must point to a span of text within the same 'unit' (allowed referencing patterns: ref="#id" or ref="id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc3">
+        <sch:rule context="mtc:match[@subType]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#candidates_subtype"
+                test="@type" >
+                'subType' attribute is used, but the 'type attribute is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc4">
+        <sch:rule context="mtc:match//xlf:sc[@isolated='no' or not(@isolated)]">
+            <sch:assert test="ancestor::mtc:match//xlf:ec[@startRef=current()/@id]">
+                There must not be any unhandled orphan elements. The 'ec' element corresponding to this start code is missing in the same 'ctr:contentItem'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="mtc5">
+        <sch:rule context="mtc:match//xlf:sm">
+            <sch:assert test="ancestor::mtc:match//xlf:em[@startRef=current()/@id]">
+                There must not be any unhandled orphan elements. The 'em' element corresponding to this start marker is missing in the same 'ctr:contentItem'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/metadata.sch
+++ b/sch/2.1/metadata.sch
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Metadata module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="mda" uri="urn:oasis:names:tc:xliff:metadata:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    
+    <sch:pattern id="mda1">
+        <sch:rule context=" mda:metaGroup[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#meta_id"
+                test="ancestor::mda:metadata[@id=$id] or count(ancestor::mda:metadata//mda:metaGroup[@id=$id])>1">
+                id duplication found. The value of id attribute (<sch:value-of select="$id"/>) must be unique among all 'mda:metaGroup' elements and the ancestor 'mda:metedata' element within the scope of the module. 
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/resource_data.sch
+++ b/sch/2.1/resource_data.sch
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Resource Data module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="res" uri="urn:oasis:names:tc:xliff:resourcedata:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>
+    <sch:pattern id="res1">
+        <sch:rule context="res:resourceItemRef[@id] | res:resourceItem[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_resourceItemRef"
+                test="count(ancestor::res:resourceData//res:resourceItem[@id=$id] | ancestor::res:resourceData//res:resourceItemRef[@id=$id])>1">
+                id duplication found among 'res:resourceItemRef' and/or 'res:resourceItem' elements within the enclosing 'resourceData' element. 
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res2">
+        <sch:rule context="res:resourceItem[not(@mimeType)]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_resourceItem"
+                test="./res:source/* and ./res:target/*">
+                The children 'res:source' and/or 'res:target' elements are empty, but the mimeType attribute is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res3">
+        <sch:rule context="res:source">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_source"
+                test="not(@href) and not(child::node())">
+                'res:source' element must not be empty when the 'href' attribute is missing.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_source"
+                test="@href and  child::node()">
+                'res:source' element must be empty when containing 'href' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res4">
+        <sch:rule context="res:source[@xml:lang]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:let name="srcLang" value="/xlf:xliff/@srcLang"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_source"
+                test="lang($srcLang)">
+                xml:lang attribute of 'res:source' element and 'srcLang' of enclosing 'xliff' are not matching.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res5">
+        <sch:rule context="res:target">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_target"
+                test="not(@href) and not(child::node())">
+                'res:target' element must not be empty when the 'href' attribute is missing.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_target"
+                test="@href and  child::node()">
+                'res:target' element must be empty when containing 'href' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res6">
+        <sch:rule context="res:target[@xml:lang]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:let name="trgLang" value="ancestor::xlf:xliff/@trgLang"/>
+            <sch:assert diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#res_target"
+                test="lang($trgLang)">
+                xml:lang attribute of 'res:target' element and 'trgLang' of enclosing 'xliff' are not matching.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="res7">
+        <sch:rule context="res:resourceItemRef">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#res_ref"
+                test="ancestor::xlf:file//res:resourceData/res:resourceItem[@id=$ref]">
+                The 'res:resourceItem' element, to which the 'res:resourceItemRef' is pointing was not found at the file level (allowed referencing pattern: ref="id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+
+
+</sch:schema>

--- a/sch/2.1/size_restriction.sch
+++ b/sch/2.1/size_restriction.sch
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Size and Length Restriction module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="slr" uri="urn:oasis:names:tc:xliff:sizerestriction:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>    
+    <sch:pattern id="slr1">
+        <sch:rule context="xlf:*[@slr:sizeInfoRef]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#slr_size_info"
+                test="not(@slr:sizeInfo)">
+                The slr:sizeInfoRef and slr:sizeInfo attributes cannot appear together. 
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/validation.sch
+++ b/sch/2.1/validation.sch
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cos01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Candidate OASIS Standard 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "12 October &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding='xslt2'>
+    <sch:title>Schematron rules for checking the constraints of the Validation module against XLIFF Version &version;</sch:title>
+    <sch:ns prefix="val" uri="urn:oasis:names:tc:xliff:validation:2.0"/>
+    <sch:ns prefix="xlf" uri="urn:oasis:names:tc:xliff:document:2.0"/>    
+    <sch:pattern id="val1">
+        <sch:rule context="val:rule" see="&this-loc;/&name;-&stage;.html#val_rule">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" test="@isPresent and (@isNotPresent or @startsWith or @ endsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="@isNotPresent and (@isPresent or @startsWith or @ endsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="@startsWith and (@isPresent or @isNotPresent  or @ endsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="@endsWith and (@isPresent or @isNotPresent  or @ startsWith)">
+                Only one of isPresent, isNotPresent, startsWith or endsWith is allowed.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" test="not(@isPresent) and not(@isNotPresent) and not(@startsWith) and not(@ endsWith) and not(@*[namespace-uri()!='urn:oasis:names:tc:xliff:validation:2.0'])">
+                When native module attributes isPresent, isNotPresent, startsWith or endsWith are not used, a custom attribute must be set for 'val:rule' element.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="val2">
+        <sch:rule context="val:rule[@occurs]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#val_occurs" test="not(@isPresent)">
+                The occure attribute can only be used in pair with isPresent
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="val3">
+        <sch:rule context="val:rule[@existsInSource]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#val_existsInSource"
+                test="(@isPeresent and not(@startsWith) and not(@endsWith)) or 
+                              (@startsWith and not(@isPeresent) and not(@endsWith)) or 
+                              (@endsWith and not(@isPeresent) and not(@startsWith))">
+                The 'existsInSourc'e attribute must be used with exactly one of 'isPresent', 'startsWith' or 'endsWith' attributes. 
+            </sch:assert>
+        </sch:rule> 
+    </sch:pattern>
+    <sch:pattern id="val4">
+        <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+        <sch:rule context="val:rule[@disabled='yes']">
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#val_disabled"
+                test="local-name(../..)='file'">
+                The disabled attribute cannot be set to 'yes' when the Validation Module is at the 'file' level.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!--<sch:pattern>
+        <sch:rule context="val:rule[@startsWith][not(@disabled) or @disabled='no']">
+            <sch:let name="start-pattern" value="@startsWith"/>
+            <sch:let name="eligible-targets" value="count(../..//xlf:target[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])])"/>
+            <sch:let name="valid-targets" value="count(../..//xlf:target[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][starts-with(.,$start-pattern)])"/>
+            <sch:let name="eligible-sources" value="count(../..//xlf:source[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])])"/>
+            <sch:let name="valid-sources" value="count(../..//xlf:source[parent::xlf:segment][not(ancestor::xlf:group/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][not(ancestor::xlf:unit/val:validation/val:rule[@startsWith=$start-pattern][@disabled='yes'])][starts-with(.,$start-pattern)])"/>
+            <sch:assert test="((not(@existsInSource) or @existsInSource='no')) or
+                (@existsInSource='yes' and $eligible-sources=$valid-sources) and $valid-targets=$eligible-targets">
+                The startsWith pattern is violated.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>-->
+   <!-- <sch:pattern>
+        <sch:rule context="val:rule[@isPresent][local-name(../..)='file']">
+            <sch:let name="isPresent" value="current()/@isPresent"/>
+            <sch:let name="unit-override" value="count(../..//xlf:unit[descendant::val:rule[@isPresent=$isPresent][@disabled='yes']])"/>
+            <sch:let name="group-override" value="count(../..//xlf:group[descendant::val:rule[@isPresent=$isPresent][@disabled='yes']])"/>
+            <sch:let name="tester" value="../..//xlf:target"/>
+            <sch:report test="true()">
+                REPORTER <sch:value-of select="$override"/>
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>-->
+    
+    <sch:diagnostics>
+        <sch:diagnostic id="spec-quote"></sch:diagnostic>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/2.1/xliff_core_2.1.sch
+++ b/sch/2.1/xliff_core_2.1.sch
@@ -1,0 +1,959 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE schematron [
+<!-- Entities for XLIFF V2.x publishing.................................... -->
+<!--copy all of these to all *.sch files and also to the Oxygen framework for validating Docbook 4.5 if you use Oxygen -->
+<!ENTITY name "xliff-core-v2.1">
+<!ENTITY pversion "2.0">
+<!ENTITY version "2.1">
+<!ENTITY bschversion "2.0">
+<!ENTITY cschversion "2.1">
+
+<!ENTITY stage "cs01">
+<!ENTITY pstage "csprd04">
+<!ENTITY standard "Committee Specification 01">
+<!ENTITY this-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&stage;">
+<!ENTITY previous-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;/&pstage;">
+<!ENTITY latest-loc "http://docs.oasis-open.org/xliff/xliff-core/v&version;">
+<!ENTITY pubdate "23 August &pubyear;">
+<!ENTITY pubyear "2017">
+<!ENTITY releaseinfo "Standards Track Work Product">
+<!-- End of XLIFF V2.x publishing entities -->
+]>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2">
+    <sch:title>Schematron Rules for Advanced Validation of XLIFF &version; Core constraints</sch:title>
+    <!-- Namespace Declarations -->
+    <sch:ns uri="urn:oasis:names:tc:xliff:document:2.0" prefix="xlf"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:matches:2.0" prefix="mtc"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:glossary:2.0" prefix="gls"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:fs:2.0" prefix="fs"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:metadata:2.0" prefix="mda"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:resourcedata:2.0" prefix="res"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:changetracking:2.1" prefix="ctr"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:sizerestriction:2.0" prefix="slr"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:validation:2.0" prefix="val"/>
+    <sch:ns uri="http://www.w3.org/2005/11/its" prefix="its"/>
+    <sch:ns uri="urn:oasis:names:tc:xliff:itsm:2.1" prefix="itsm"/>
+    <!-- End of Namespace Declarations -->
+    
+    <!-- Rules for primary keys -->
+    <sch:pattern id="K1">
+        <sch:title>The value [of id] must be unique among all 'file' id attribute values within the enclosing 'xliff' element</sch:title>
+        <sch:rule context="xlf:file">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:file[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'file' elements 
+                within the enclosing 'xliff'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K2">
+        <sch:title>The value [of id] must be unique among all 'group' id attribute values within the enclosing 'file' element</sch:title>
+        <sch:rule context="xlf:group">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/g=',$id)"/>
+            <sch:report diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:file//xlf:group[@id=$id])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'group' elements 
+                within the enclosing 'file'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K3">
+        <sch:title>The value [of id] must be unique among all 'unit' id attribute values within the enclosing 'file' element</sch:title>
+        <sch:rule context="xlf:unit">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:file//xlf:unit[@id=$id])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'unit' elements 
+                within the enclosing 'file'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- K4F (file) and K4GU (group/unit) are distinguished for accurate fragID report -->
+    <sch:pattern id="K4F">
+        <sch:title>The value [of id] must be unique among all 'note' id attribute values within the enclosing 'notes' element</sch:title>
+        <sch:rule context="xlf:note[@id][not(ancestor::xlf:unit)][not(ancestor::xlf:group)]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/n=',$id) "/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.htmll#id"
+                test="following-sibling::xlf:note[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'note' elements 
+                within the enclosing 'notes'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K4GU">
+        <sch:title>The value [of id] must be unique among all 'note' id attribute values within the enclosing 'notes' element</sch:title>
+        <sch:rule context="xlf:note[@id][ancestor::xlf:unit | ancestor::xlf:group]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,concat('/',substring(local-name(../..),1,1),'=',../../@id),'/n=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:note[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'note' elements 
+                within the enclosing 'notes'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- K5C (Core), K5MTC (MTC Module) and K5CTR (CTR Module) are distinguished for accurate fragID report and observing independency of the modules -->
+    <sch:pattern id="K5C">
+        <sch:title>The value [of id] must be unique among all 'data' id attribute values within the enclosing 'originalData' element</sch:title>
+        <sch:rule context="xlf:data[local-name(../..)='unit']">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/d=',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="following-sibling::xlf:data[@id=$id]">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more than once for 'data' elements 
+                within the enclosing 'originalData'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- K6S (source) and K6T (target) are distinguished for accurate fragID report -->
+    <sch:pattern id="K6S">
+        <sch:title>Except for the above exception [target duplication], the value [of id attribute] must be unique among all of the above 
+            [segment, ignorable, mkr, sm,pc, sc, ec, ph] within the enclosing 'unit' element</sch:title>
+        <sch:rule context="xlf:source[ancestor::xlf:segment| ancestor::xlf:ignorable]//xlf:*[@id]|
+            xlf:segment[@id]| xlf:ignorable[@id]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',$id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="count(ancestor::xlf:unit//xlf:*[@id=$id][ancestor-or-self::xlf:segment| ancestor-or-self::xlf:ignorable][not(ancestor::xlf:target)])>1">
+                id duplication found. The value '<sch:value-of select="$id"/>' is used more then once among inline and/or 'segmen'/'ignorable' 
+                elements within the enclosing 'unit'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K6T">
+        <sch:title>The inline elements enclosed by a 'target' element must use the duplicate id values of their corresponding inline elements enclosed within the sibling 'source' element if and only if those corresponding elements exist</sch:title>
+        <sch:rule context="xlf:target[ancestor::xlf:segment | ancestor::xlf:ignorable]//xlf:*[@id]">
+            <sch:let name="id" value="@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id,'/u=',$unit-id,'/t=',$id)"/>
+            <sch:let name="counter" value="count(ancestor::xlf:unit//xlf:*[@id=$id]
+                [ancestor-or-self::xlf:segment| ancestor-or-self::xlf:ignorable])"/>
+            <!-- If the counter is 1, then the id is unique and therefore valid -->
+            <!-- If the counter is 2 (duplication exsists), the duplication must be 
+            in the sibling source, have the same name and contain same attributes-->
+            <!-- If the counter is more than 2 or the duplication is not in the right 
+            position, then an error will be reported -->
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#id"
+                test="($counter=1) or ($counter=2 and
+                count(ancestor::xlf:segment/xlf:source//xlf:*[@id=$id]
+                [local-name()= local-name(current())]| 
+                ancestor::xlf:ignorable/xlf:source//xlf:*[@id=$id][local-name()= 
+                local-name(current())])=1)">
+                Invalid id used for element '<sch:name/>'. It must duplicate the 
+                id of its corresponding element, enclosed within the 'source' 
+                element or be unique in the scope of 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="K7">
+        <sch:title>The value of the order attribute must be unique within the enclosing 'unit' element</sch:title>
+        <sch:rule context="xlf:target[@order][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="order" value="@order"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report diagnostics="fragid-report"  see="&this-loc;/&name;-&stage;.html#order"
+                test="count(ancestor::xlf:unit//xlf:target[ancestor::xlf:segment|ancestor::xlf:ignorable][@order=$order])>1">
+                The value '<sch:value-of select="$order"/>' is used more than once for 'order' attributes of 'target' elements 
+                within the enclosing 'unit'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- End of Rules for primary keys -->
+    
+    <!-- Remaining Rules -->
+    <sch:pattern id="F1">
+        <sch:title>The 'trgLang' attribute is required if and only if the XLIFF Document contains 'target' elements 
+            that are children of 'segment' or 'ignorable'</sch:title>
+        <sch:rule context="xlf:target[parent::xlf:segment | parent::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#xliff" 
+                test="/xlf:xliff/@trgLang">
+                XLIFF document contains 'target' element(s), but the 'trgLang' attribute of 'xliff' is missing.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F2">
+        <sch:title>The attribute 'href' is required if and only if the 'skeleton' element is empty</sch:title>
+        <sch:rule context="xlf:skeleton">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#skeleton"
+                test="not(@href) and not(child::node())">
+                'skeleton' element must not be empty when the 'href' attribute is missing.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#skeleton"
+                test="@href and  child::node()">
+                'skeleton' element must be empty when containing 'href' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F3">
+        <sch:title>A 'unit' must contain at least one 'segment' element</sch:title>
+        <sch:rule context="xlf:unit">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', current()/@id)"/>
+            <sch:report  diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#unit"
+                test="not(child::xlf:segment)">
+                Incomplete 'unit'; it must have at least one 'segment' child.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F4S">
+        <sch:title>When a 'source' element is a child of 'segment' or 'ignorable', the explicit or inherited value
+            of the optional xml:lang must be equal to the value of the srcLang attribute of the enclosing 'xliff' 
+            element</sch:title>
+        <sch:p>This rule does not rais an error if 'xml:lang' is a subcategory of 'srcLang', but not vice versa.
+            i.e. 'srcLang="en"/xml:lang="en-ie"' is a valid pair.</sch:p>
+        <sch:rule context="xlf:source[@xml:lang][parent::xlf:segment | parent::xlf:ignorable]">
+            <sch:let name="srcLang" value="/xlf:xliff/@srcLang"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report  diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#target"
+                test="not(lang($srcLang))">
+                'xml:lang' attribute of the 'source' element and 'srcLang' attribute of the 'xliff' are not matching.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F4T">
+        <sch:title>When a 'target' element is a child of 'segment' or 'ignorable', the explicit or inherited value
+            of the optional xml:lang must be equal to the value of the trgLang attribute of the enclosing 'xliff' 
+            element</sch:title>
+        <sch:p>This rule does not rais an error if 'xml:lang' is a subcategory of 'trgLang', but not vice versa.
+            i.e. 'trgLang="en"/xml:lang="en-ie"' is a valid pair.</sch:p>
+        <sch:rule context="xlf:target[@xml:lang][parent::xlf:segment | parent::xlf:ignorable]">
+            <sch:let name="trgLang" value="/xlf:xliff/@trgLang"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id)"/>
+            <sch:report  diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#target"
+                test="not(lang($trgLang))">
+                'xml:lang' attribute of the 'target' element and 'trgLang' attribute of the 'xliff' are not matching.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5S">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'yes' and appear in 'source'. 
+            An error will be raised if there exists any 'ec' in the same 'unit' and in a 'source', corresponding to this 'sc' by 'startRef'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:source][@isolated='yes'][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="ancestor::xlf:unit//xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+                'isolated' attribute is set to 'yes', but 'ec' element(s) referencing this start code found within the same unit.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5T">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'yes' and appear in 'target'. 
+            An error will be raised if there exists any 'ec' in the same 'unit' and in a 'target', corresponding to this 'sc' by 'startRef'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:target][@isolated='yes'][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/t=', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="ancestor::xlf:unit//xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+                'isolated' attribute is set to 'yes', but 'ec' element(s) referencing this start code found within the same unit.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5.1S">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'no' (or missing) and appear in 'source'. 
+            An error will be raised if
+            a) there is not one and only one 'ec' element in the same 'unit', in a 'source', which appears after the 'sc' 
+            and corresponds to this 'sc' by 'startRef';
+            b) the values of 'canCopy', 'canDelete', 'canReorder' or 'canOverlap' attributes are not matching with the 
+            corresponding ec;
+            c) the value of 'canReorder' is set to 'firstNo', but is not 'no' in the corresponding 'ec'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable][@isolated='no'] | 
+            xlf:sc[ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable][not(@isolated)]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/', $id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="count(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit[@id=$unit-id]][ancestor::xlf:file[@id=$file-id]])=1">
+                'isolated' attribute is set to 'not', but the corresponding 'ec' element within the same 'unit' was not found. 
+                The end code must appear after the start code.
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canCopy='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='no'])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canCopy='yes' or not(@canCopy)) and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canCopy)])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canDelete='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='no'])">
+                'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canDelete='yes' or not(@canDelete)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canDelete)])">
+                'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canReorder='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canReorder='yes' or not(@canReorder)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canReorder)])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canOverlap='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='no'])">
+                'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canOverlap='yes' or not(@canOverlap)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canOverlap)])">
+                'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="@canReorder='firstNo' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:source][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' is set to 'firstNo', but the corresponding 'ec', within the same 'unit'
+                has not set its 'canReorder' attribute to 'no'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F5.1T">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'ec' element corresponding to this
+            start marker is not in the same 'unit', and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'sc' with 'isolated' attribute set to 'no' (or missing) and appear in 'target'. 
+            An error will be raised if
+            a) there is not one and only one 'ec' element in the same 'unit', in a 'target', which appears after the 'sc' 
+            and corresponds to this 'sc' by 'startRef';
+            b) the values of 'canCopy', 'canDelete', 'canReorder' or 'canOverlap' attributes are not matching with the 
+            corresponding ec;
+            c) the value of 'canReorder' is set to 'firstNo', but is not 'no' in the corresponding 'ec'</sch:p>
+        <sch:rule context="xlf:sc[ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable][@isolated='no'] | 
+            xlf:sc[ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable][not(@isolated)]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id, '/t=', $id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#isolated"
+                test="count(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit[@id=$unit-id]][ancestor::xlf:file[@id=$file-id]])=1">
+                'isolated' attribute is set to 'not', but the corresponding 'ec' element within the same 'unit' was not found.
+                The end code must appear after the start code.
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canCopy='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='no'])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canCopy='yes' or not(@canCopy)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canCopy='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canCopy)])">
+                'canCopy' attribute is not matching with the 'canCopy' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canDelete='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='no'])">
+                'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canDelete='yes' or not(@canDelete)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canDelete='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canDelete)])">
+                The 'canDelete' attribute is not matching with the 'canDelete' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canReorder='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canReorder='yes' or not(@canReorder)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canReorder='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canReorder)])">
+                'canReorder' attribute is not matching with the 'canReorder' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="@canOverlap='no' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target]
+                [ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='no'])">
+                'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#sc"
+                test="(@canOverlap='yes' or not(@canOverlap)) and not(following::xlf:ec[@startRef=$id]
+                [ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id][@canOverlap='yes']) and 
+                not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][not(@canOverlap)])">
+                The 'canOverlap' attribute is not matching with the 'canOverlap' attribute of the corresponding 'ec' element within the same 'unit'.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="@canReorder='firstNo' and not(following::xlf:ec[@startRef=$id][ancestor::xlf:target][ancestor::xlf:unit/@id=$unit-id]
+                [ancestor::xlf:file/@id=$file-id][@canReorder='no'])">
+                'canReorder' is set to 'firstNo', but the corresponding 'ec', within the same 'unit'
+                has not set its 'canReorder' attribute to 'no'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F6S">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'sc' element corresponding to this
+            end code [ec] is not in the same 'unit' and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'ec' which are in 'source' and raises an error if
+            a) 'id' and 'startRef' attributes are used illegally, based on the value of 'isolated': if 'yes',
+            only 'id' must be used and if 'no' (or missing), only 'startRef' must be specified;
+            b) 'isolated' is 'no' (or missing)) and the 'dir' attribute is used;
+            c)'isolated' is set to 'no', but there is no 'sc' in the same 'unit', in a 'source' and which
+            appears before this end code.
+        </sch:p>
+        <sch:rule context="xlf:ec[ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='yes' and @id and not(@startRef)) or 
+                ((@isolated='no' or not(@isolated)) and @startRef and not(@id))">
+                Illegal use of 'id' and 'startRef' atribute. If 'isolated' is set to 'yes', only 'id' must be 
+                used and if set to 'no' (or missing), only 'startRef' must be specified
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and @dir">
+                The 'dir' attribute may be used only when the attribute 'isolated' is set to 'yes'
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and count(preceding::xlf:sc[@id=current()/@startRef][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]
+                [ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][not(@isolated='yes')])!=1">
+                'isolated' attribute is set to 'not', but the corresponding 'sc' element within the same 'unit' was not found. 
+                The start code must appear befor the end code
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F6T">
+        <sch:title>The attribute isolated must be set to yes if and only if the 'sc' element corresponding to this
+            end code [ec] is not in the same 'unit' and set to no otherwise</sch:title>
+        <sch:p>This rule selects those 'ec' which are in 'target' and raises an error if
+            a) 'id' and 'startRef' attributes are used illegally, based on the value of 'isolated': if 'yes',
+            only 'id' must be used and if 'no' (or missing), only 'startRef' must be specified;
+            b)'isolated' is set to 'no' (or missing), but there is no 'sc' in the same 'unit', in a 'target' and which
+            appears before this end code.
+            c) 'isolate' is set to 'no' (or missing) and 'dir' attribute is used. 
+        </sch:p>
+        <sch:rule context="xlf:ec[ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:let name="fragid" value="concat('f=', $file-id, '/u=', $unit-id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='yes' and @id and not(@startRef)) or 
+                ((@isolated='no' or not(@isolated)) and @startRef and not(@id))">
+                Illegal use of 'id' and 'startRef' atribute. If 'isolated' is set to 'yes', only 'id' must be 
+                used and if set to 'no' (or missing), only 'startRef' must be specified
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and @dir">
+                The 'dir' attribute may be used only when the attribute 'isolated' is set to 'yes'
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#ec"
+                test="(@isolated='no' or not(@isolated)) and count(preceding::xlf:sc[@id=current()/@startRef][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]
+                [ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][not(@isolated='yes')])!=1">
+                'isolated' attribute is set to 'not', but the corresponding 'sc' element within the same 'unit' was not found. 
+                The start code must appear befor the end code.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F7">
+        <sch:title>If the attribute subState is used, the attribute state must be explicitly set</sch:title>
+        <sch:rule context="xlf:segment[@subState]" >
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id, '/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#substate"
+                test="@state" >
+                'segment' element specifies 'subState' attribute, but missing the 'state' attribute.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F8">
+        <sch:title>If the attribute 'subType' is used, the attribute 'type' must be specified as well</sch:title>
+        <sch:p>This rule select inline elements, which specify 'subType'. It also checks the value of 'subType'.</sch:p>
+        <sch:rule context="xlf:*[@subType][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subtype"
+                test="@type">
+                '<sch:name/>' element specifies 'subType' attribute, but missing the 'type' attribute.
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subtype"
+                test="((@subType='xlf:i' or @subType='xlf:u' or @subType='xlf:lb' or @subType='xlf:pb' or @subType='xlf:b')and( @type='fmt')) or
+                (@subType='xlf:var' and @type='ui') or not(starts-with(@subType,'xlf:'))">
+                'type' and 'subType' attributes don't match. Value of 'type' must either be set to a user-defined value, 
+                or to 'ui' when 'subType=xlf:var', or to 'fmt' for following values of 'subType':'xlf:i','xlf:u','xlf:lb' and 'xlf:pb'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F9">
+        <sch:title>The copyOf attribute must be used when, and only when, the base code has no associated original data</sch:title>
+        <sch:rule context="xlf:*[@copyOf][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="local-name()='pc' and (@dataRefStart or @dataRefEnd)">
+                'pc' cannot use 'copyOf' attribute while referring to the original data through 'dataRefStart/dataRefEnd' attributes.
+            </sch:report>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="local-name()!='pc' and @dataRef">
+                '<sch:name/>' cannot use 'copyOf' attribute while referring to the original data through 'dataRef' attribute.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F10">
+        <sch:title>When the attribute canReorder is set to no or firstNo, the attributes canCopy and canDelete must also be set to no</sch:title>
+        <sch:rule context="xlf:*[@canReorder='no'][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:*[@canReorder='firstNo'][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints"
+                test="@canDelete='no' and @canCopy='no'">
+                '<sch:name/>' element has set its 'canReorder' attribute to '<sch:value-of select="@canReorder"/>', but 'canDelete' and 
+                'canCopy' attributes are not set to 'no'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F11S">
+        <sch:title>Translate Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='generic'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:sm[not(@type)][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] |
+            xlf:mrk[@type='generic'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:mrk[not(@type)][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#translateAnnotation"
+                test="@translate" role="warning">
+                '<sch:name/>' element seems to be used for translate annotaition, but missing the 'translate' attribute.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F11T">
+        <sch:title>Translate Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='generic'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]|xlf:sm[not(@type)][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]|
+            xlf:mrk[@type='generic'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable] | xlf:mrk[not(@type)][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#translateAnnotation"
+                test="@translate" role="warning">
+                '<sch:name/>' element seems to be used for translate annotaition, but missing the 'translate' attribute.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F12S">
+        <sch:title>Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]|xlf:mrk[@type='comment'][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f', ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="(@value and not(@ref))or(@ref and not(@value))">
+                '<sch:name/>' element must contain one and only one of 'value' and 'ref' attributes when used for comment annotation.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F12T">
+        <sch:title>Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]|xlf:mrk[@type='comment'][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="(@value and not(@ref))or(@ref and not(@value))">
+                '<sch:name/>' element cannot contain both 'value' and 'ref' attributes simultaneously when used for comment annotation.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F13S">
+        <sch:title>ref attribute in Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][@ref][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable] |
+            xlf:mrk[@type='comment'][@ref][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="count(ancestor::xlf:unit//xlf:note[@id= substring-after($ref,'#n=')])=1">
+                'ref' attribute of '<sch:name/>' must point to a 'note' element within the same unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F13T">
+        <sch:title>ref attribute in Comment Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='comment'][@ref][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable] | 
+            xlf:mrk[@type='comment'][@ref][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="ref" value="@ref"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#commentAnnotation"
+                test="count(ancestor::xlf:unit//xlf:note[@id= substring-after($ref,'#n=')])=1">
+                'ref' attribute of '<sch:name/>' must point to a 'note' element within the same unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F14">
+        <sch:title>The 'copyOf' attribute must point to a code within the same 'unit'</sch:title>
+        <sch:rule context="xlf:*[@copyOf][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="copyOf" value="@copyOf"/>
+            <sch:let name="fragid" value="concat(ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="ancestor::xlf:unit//xlf:*[ancestor::xlf:segment | ancestor::xlf:ignorable][@id=$copyOf]">
+                No inline element with 'id=<sch:value-of select="$copyOf"/>' found within the same 'unit' (allowed referencing pattern: copyOf="id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="ancestor::xlf:unit//xlf:*[ancestor::xlf:segment | ancestor::xlf:ignorable][@id=$copyOf][not(@dataRef)][not(@dataRefStart)][not(@dataRefEnd)]">
+                If an inline code has associated original data (referes to a 'data' element), it cannot be replicated.
+            </sch:assert>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#duplicatingexistingcode"
+                test="ancestor::xlf:unit//xlf:*[ancestor::xlf:segment | ancestor::xlf:ignorable][@id=$copyOf][@canCopy='no']">
+                The 'canCopy' attribute of the inline element with id='<sch:value-of select="$copyOf"/>' is set to 'no' and therefore cannot be replicated.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F15">
+        <sch:title>dataRef attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:*[@dataRef][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#dataref"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRef]">
+                'dataRef' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRef="data-id").
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F16S">
+        <sch:title>dataRefEnd attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefEnd][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefend"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefEnd]">
+                'dataRefEnd' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefEnd="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefStart">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F16T">
+        <sch:title>dataRefEnd attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefEnd][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefend"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefEnd]">
+                'dataRefEnd' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefEnd="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefStart">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F17S">
+        <sch:title>dataRefStart attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefStart][ancestor::xlf:source][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefstart"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefStart]">
+                'dataRefStart' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefStart="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefEnd">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F17T">
+        <sch:title>dataRefStart attribute must point to a data element within the same unit</sch:title>
+        <sch:rule context="xlf:pc[@dataRefStart][ancestor::xlf:target][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',ancestor::xlf:unit/@id,'/t=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#datarefstart"
+                test="ancestor::xlf:unit/xlf:originalData/xlf:data[@id=current()/@dataRefStart]">
+                'dataRefStart' attribute must point to a 'data' element within the same 'unit' (allowed referencing pattern: dataRefStart="data-id").
+            </sch:assert>
+            <sch:assert diagnostics="fragid-report" test="@dataRefEnd">
+                'dataRefEnd' and 'dataRefStart' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F18">
+        <sch:title>Its value [order attribute] is an integer from 1 to N, where N is the sum of the numbers of the 'segment' 
+            and 'ignorable' elements within the given enclosing 'unit' element</sch:title>
+        <sch:rule context="xlf:unit">
+            <sch:let name="maxOrder" value="count(xlf:segment|xlf:ignorable)"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',current()/@id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#segorder"
+                test="descendant::xlf:target[@order>$maxOrder][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+                Invalid value used for order attribute of 'target' element(s). It must be an integer from 1 to <sch:value-of select="$maxOrder"/>.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F19">
+        <sch:title>To be able to map order differences, the 'target' element has an optional order attribute that indicates its position in the sequence of segments (and inter-segments). Its value is an
+            integer from 1 to N, where N is the sum of the numbers of the 'segment' and 'ignorable' elements within the given enclosing 'unit' element.
+            When Writers set explicit order on 'target' elements, they have to check for conflicts with implicit order, as 'target' elements without explicit
+            order correspond to their sibling 'source' elements</sch:title>
+        <sch:rule context="xlf:target[@order][ancestor::xlf:segment | ancestor::xlf:ignorable]">
+            <sch:let name="order" value="@order"/>
+            <sch:let name="actual-pos" value="count(../preceding-sibling::xlf:segment| ../preceding-sibling::xlf:ignorable)+1"/>
+            <sch:let name="fragid" value="concat('f=',ancestor::xlf:file/@id,'/u=',current()/@id)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#segorder"
+                test="ancestor::xlf:unit//xlf:target[@order=$actual-pos][ancestor::xlf:segment | ancestor::xlf:ignorable]"> 
+                The corresponding 'target' element, 'order' attribute of which must be '<sch:value-of select="$actual-pos"/>', is missing within the enclosing 'unit'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:*[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][not(@startRef)]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints"
+                test="(ancestor::xlf:segment/target) and 
+                (not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][local-name()=local-name(current())]))">
+                All inline elements with 'canDelete' attribute set to 'no'must have their corresponding elements in the sibling 'target'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20ec">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:ec[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][@startRef]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints"
+                test="(ancestor::xlf:segment/target) and 
+                (not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]))">
+                All inline elements with 'canDelete' attribute set to 'no'must have their corresponding elements in the sibling 'target'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20W">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:*[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][not(@startRef)]" role="warn">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:segment[not(@state='final')] and ancestor::xlf:segment/xlf:target and 
+                not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][local-name()=local-name(current())])">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target (not an error since 'state' attribute of the containing 'segment' is not 
+                final').
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20W-ig">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:*[@canDelete='no'][ancestor::xlf:ignorable][ancestor::xlf:source][not(@startRef)]" role="warn">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:ignorable/xlf:target and 
+                not(ancestor::xlf:ignorable/xlf:target//xlf:*[@id=$id][local-name()=local-name(current())])">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20Wec">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:ec[@canDelete='no'][ancestor::xlf:segment][ancestor::xlf:source][@startRef]" role="warn">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:segment[not(@state='final')] and ancestor::xlf:segment/xlf:target and 
+                (not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]))">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target (not an error since 'state' attribute of the containing 'segment' is not 
+                final').
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F20Wec-ig">
+        <sch:title>Modifiers must not delete inline codes that have their attribute canDelete set to no</sch:title>
+        <sch:rule context="xlf:ec[@canDelete='no'][ancestor::xlf:ignorable][ancestor::xlf:source][@startRef]" role="warn">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id,'/u=', ancestor::xlf:unit/@id,'/', $id)"/>
+            <sch:report diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#editinghints" role="warning"
+                test="ancestor::xlf:ignorable/xlf:target and 
+                (not(ancestor::xlf:ignorable/xlf:target//xlf:ec[@startRef=$id]))">
+                WARNING: 'canDelete' attribute is set to 'no', but the corresponding element is missing in the sibling target.
+                final').
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F21">
+        <sch:title>subFlows must point to units within the same file</sch:title>
+        <sch:rule context="xlf:*[@subFlows][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:let name="sub-flows" value=" normalize-space(@subFlows)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFlows" 
+                test="count(tokenize($sub-flows,' '))=count(ancestor::xlf:file//xlf:unit[@id=tokenize($sub-flows,' ')])">
+                The 'subFlows' attribute must contain a space-seperated list of 'unit' identifiers within the same 'file'.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F22">
+        <sch:title>subFlowsEnd must point to units within the same file</sch:title>
+        <sch:rule context="xlf:pc[@subFlowsEnd][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:let name="sub-flows" value=" normalize-space(@subFlowsEnd)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFlows" 
+                test="count(tokenize($sub-flows,' '))=count(ancestor::xlf:file//xlf:unit[@id=tokenize($sub-flows,' ')])">
+                The 'subFlowsEnd' attribute must contain a space-seperated list of 'unit' identifiers within the same 'file'.
+            </sch:assert>
+            <sch:assert test="@subFlowsStart">
+                'subFlowsStart' and 'subFlowsEnd' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F23">
+        <sch:title>subFlowsStart must point to units within the same file</sch:title>
+        <sch:rule context="xlf:pc[@subFlowsStart][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:let name="fragid" value="concat('f=', ancestor::xlf:file/@id, '/u=', ancestor::xlf:unit/@id)"/>
+            <sch:let name="sub-flows" value=" normalize-space(@subFlowsStart)"/>
+            <sch:assert diagnostics="fragid-report" see="&this-loc;/&name;-&stage;.html#subFlows" 
+                test="count(tokenize($sub-flows,' '))=count(ancestor::xlf:file//xlf:unit[@id=tokenize($sub-flows,' ')])">
+                The 'subFlowsStart' attribute must contain a space-seperated list of 'unit' identifiers within the same 'file'.
+            </sch:assert>
+            <sch:assert test="@subFlowsEnd">
+                'subFlowsStart' and 'subFlowsEnd' must be used in pair.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F24">
+        <sch:title>Translation Candidate Annotation</sch:title>
+        <sch:rule context="xlf:sm[@type='mtc:match'][ancestor::xlf:segment|ancestor::xlf:ignorable] | xlf:mrk[@type='mtc:match'][ancestor::xlf:segment|ancestor::xlf:ignorable]">
+            <sch:report test="@ref">
+                'ref' attribute is not allowed in Translation Candidate Annotation, when the 'type' attribute is set to 'mtc:match'.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F25">
+        <sch:rule context="xlf:cp">
+            <sch:let name="hex" value="current()/@hex"/>
+            <!--<sch:assert test="matches(@hex,'^([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]|[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]|[01][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])$')">
+                The value of 'hex' attribute must be in  the hexadecimal inclusive range of 0000 to 10FFFF. 
+            </sch:assert>-->
+            <sch:assert test="matches($hex,'^000[0-8]$') or matches($hex,'^000B|000b$') or matches($hex,'^000C|000c$') or matches($hex,'^000[EeFf]|001[0-9a-fA-F]$')
+                or matches($hex,'^007[Ff]|008[0-4]$') or matches($hex,'^008[6-9a-fA-F]|009[0-9a-fA-F]$') or matches($hex,'^[Dd][8-9a-fA-F][0-9a-fA-F][0-9a-fA-F]$') ">
+                The value of 'hex' attribute must be an illegal XML value.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F26">
+        <sch:rule context="xlf:pc[@equivStart] | xlf:pc[@equivEnd]">
+            <sch:assert test="@equivStart and @equivEnd">
+                The pair of 'equivStart'/'equivEnd' attributes must be specified together.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F27">
+        <sch:rule context="xlf:sm">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:assert test="count(following::xlf:em[@startRef=$id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id])!=0">
+                There must be an 'em' element corresponding to this start marker by the 'startRef' attribute (the end marker must appear in the same 'unit' and after the start code).
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F28">
+        <sch:rule context="xlf:em">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:assert test="count(preceding::xlf:sm[@id=$id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:file/@id=$file-id])!=0">
+                There must be an 'sm' element corresponding to this end marker by the 'id' attribute (the start marker must appear in the same 'unit' and before the end code).
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F29">
+        <sch:rule context="xlf:segment[@state='translated' or @state='reviewed' or @state='final']">
+            <sch:assert test="child::xlf:target">
+                Incorrect usage of 'state' attribute; when it is set to 'translated', 'reviewed' or 'final', the 'segment' must contain 'target' child. 
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F30S">
+        <sch:rule context="xlf:*[@canReorder='no'][ancestor::xlf:source]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:report test="(ancestor::xlf:pc and ((preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes' or not(@canReorder)]) or parent::xlf:pc[@canReorder='yes' or not(@canReorder)])) or
+                (not(ancestor::xlf:pc) and preceding::xlf:*[position()=1][ancestor::xlf:source][local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes' or not(@canReorder)])">
+                Invalid non-reorderable sequence; inline element with 'canReorder' set to 'no' must not be preceded with inline element with 'canReorder' set to 'yes' or missing
+            </sch:report>
+            <sch:assert test="(not(ancestor::xlf:pc) and count(preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:source])!=0) or
+                (ancestor::xlf:pc and count(ancestor::xlf:pc[@canReorder='firstNo'] | preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:source])!=0)">
+                Invalid non-reorderable sequence; missing the start element with 'canReorder' set to 'firstNo' within the same 'unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F30T">
+        <sch:rule context="xlf:*[@canReorder='no'][ancestor::xlf:target]">
+            <sch:let name="file-id" value="ancestor::xlf:file/@id"/>
+            <sch:let name="unit-id" value="ancestor::xlf:unit/@id"/>
+            <sch:report test="(ancestor::xlf:pc and ((preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes'or not(@canReorder)]) or parent::xlf:pc[@canReorder='yes' or not(@canReorder)])) or
+                (not(ancestor::xlf:pc) and preceding::xlf:*[position()=1][ancestor::xlf:target][local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@canReorder='yes' or not(@canReorder)])">
+                Invalid non-reorderable sequence; inline element with 'canReorder' set to 'no' must not be preceded with inline element with 'canReorder' set to 'yes' or missing
+            </sch:report>
+            <sch:assert test="(not(ancestor::xlf:pc) and count(preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:target])!=0) or
+                (ancestor::xlf:pc and count(ancestor::xlf:pc[@canReorder='firstNo'] | preceding::xlf:*[@canReorder='firstNo'][ancestor::xlf:file/@id=$file-id][ancestor::xlf:unit/@id=$unit-id][ancestor::xlf:source])!=0)">
+                Invalid non-reorderable sequence; missing the start element with 'canReorder' set to 'firstNo' within the same 'unit.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F31">
+        <sch:rule context="xlf:*[@id][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id][1]]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:*[1]/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id]/preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id=$preceding-id][1])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:*[@id][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:ec[@startRef][1]]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:ec[1]/@startRef"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id]/preceding-sibling::xlf:ec[1][@startRef=$preceding-id])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:*[@id][@canReorder='no'][ancestor::xlf:source][parent::xlf:pc][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]">
+            <sch:let name="id" value="current()/@id"/>
+            <sch:let name="parent-id" value="parent::xlf:pc/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]/parent::xlf:pc[@id=$parent-id])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <sch:pattern id="F31ec">
+        <sch:rule context="xlf:ec[@startRef][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id][1]]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:*[1]/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]/preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'][@id=$preceding-id][1])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:ec[@startRef][@canReorder='no'][ancestor::xlf:source][preceding-sibling::xlf:ec[@startRef][1]]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="preceding-id" value="preceding-sibling::xlf:ec[1]/@startRef"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:ec[@startRef=$id]/preceding-sibling::xlf:ec[@startRef=$preceding-id][1])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+        <sch:rule context="xlf:ec[@startRef][@canReorder='no'][ancestor::xlf:source][parent::xlf:pc][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]">
+            <sch:let name="id" value="current()/@startRef"/>
+            <sch:let name="parent-id" value="parent::xlf:pc/@id"/>
+            <sch:report test="ancestor::xlf:segment/xlf:target and not(ancestor::xlf:segment/xlf:target//xlf:*[@id=$id][not(preceding-sibling::xlf:*[local-name()='pc' or local-name()='sc' or local-name()='ec' or local-name()='ph'])]/parent::xlf:pc[@id=$parent-id])">
+                Non-reorderable sequence must remain unchanged in target.
+            </sch:report>
+        </sch:rule>
+    </sch:pattern>
+    <!-- End of Schematron Rules -->
+    <!-- Diagnostics used to provide fragment identification notations in accordance with sec. 3 of XLIFF Specification -->
+    <sch:diagnostics>
+        <sch:diagnostic id="fragid-report">#<sch:value-of select="$fragid"/></sch:diagnostic>
+    </sch:diagnostics>
+</sch:schema>

--- a/sch/custom_sch/progress.sch
+++ b/sch/custom_sch/progress.sch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
+    xmlns:sqf="http://www.schematron-quickfix.com/validator/process">
+    
+    <sch:pattern>
+        <sch:rule context="*:target">
+            <sch:report test="deep-equal(./node(), ../*:source/node())" role="warn">
+                Source and target content are the same, probably the content is not translated!
+            </sch:report>            
+        </sch:rule>
+    </sch:pattern>
+    
+</sch:schema>

--- a/xliff_2.1.framework
+++ b/xliff_2.1.framework
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serialized version="19.0" xml:space="preserve">
+	<serializableOrderedMap>
+		<entry>
+			<String>document.types</String>
+			<documentTypeDescriptor-array>
+				<documentTypeDescriptor>
+					<field name="extensionPatch">
+						<documentTypeDescriptorPatch>
+							<field name="patchList">
+								<list>
+									<poPatch>
+										<field name="fieldPath">
+											<String>name</String>
+										</field>
+										<field name="index">
+											<Integer>-1</Integer>
+										</field>
+										<field name="value">
+											<String>XLIFF 2.1</String>
+										</field>
+										<field name="patchHandling">
+											<String>set</String>
+										</field>
+										<field name="anchor">
+											<null/>
+										</field>
+									</poPatch>
+									<poPatch>
+										<field name="fieldPath">
+											<String>validationScenarios</String>
+										</field>
+										<field name="index">
+											<Integer>0</Integer>
+										</field>
+										<field name="value">
+											<validationScenario>
+												<field name="pairs">
+													<list>
+														<validationUnit>
+															<field name="validationType">
+																<validationUnitType>
+																	<field name="validationInputType">
+																		<String>text/any</String>
+																	</field>
+																</validationUnitType>
+															</field>
+															<field name="url">
+																<String>${currentFileURL}</String>
+															</field>
+															<field name="validationEngine">
+																<validationEngine>
+																	<field name="engineType">
+																		<String>&lt;Default engine></String>
+																	</field>
+																	<field name="allowsAutomaticValidation">
+																		<Boolean>true</Boolean>
+																	</field>
+																</validationEngine>
+															</field>
+															<field name="allowAutomaticValidation">
+																<Boolean>true</Boolean>
+															</field>
+															<field name="extensions">
+																<null/>
+															</field>
+															<field name="validationSchema">
+																<null/>
+															</field>
+														</validationUnit>
+														<validationUnit>
+															<field name="validationType">
+																<validationUnitType>
+																	<field name="validationInputType">
+																		<String>text/xml</String>
+																	</field>
+																</validationUnitType>
+															</field>
+															<field name="url">
+																<String>${currentFileURL}</String>
+															</field>
+															<field name="validationEngine">
+																<validationEngine>
+																	<field name="engineType">
+																		<String>&lt;Default engine></String>
+																	</field>
+																	<field name="allowsAutomaticValidation">
+																		<Boolean>true</Boolean>
+																	</field>
+																</validationEngine>
+															</field>
+															<field name="allowAutomaticValidation">
+																<Boolean>true</Boolean>
+															</field>
+															<field name="extensions">
+																<null/>
+															</field>
+															<field name="validationSchema">
+																<validationUnitSchema>
+																	<field name="dtdSchemaPublicID">
+																		<null/>
+																	</field>
+																	<field name="schematronPhase">
+																		<null/>
+																	</field>
+																	<field name="type">
+																		<Integer>9</Integer>
+																	</field>
+																	<field name="uri">
+																		<String>${framework}/NVDL/2.1/xliff_2_advanced_validation.nvdl</String>
+																	</field>
+																</validationUnitSchema>
+															</field>
+														</validationUnit>
+													</list>
+												</field>
+												<field name="type">
+													<String>Validation_scenario</String>
+												</field>
+												<field name="name">
+													<String>XLIFF 2.1</String>
+												</field>
+											</validationScenario>
+										</field>
+										<field name="patchHandling">
+											<String>addIndex</String>
+										</field>
+										<field name="anchor">
+											<null/>
+										</field>
+									</poPatch>
+									<poPatch>
+										<field name="fieldPath">
+											<String>defaultValidationScenarios</String>
+										</field>
+										<field name="index">
+											<Integer>-1</Integer>
+										</field>
+										<field name="value">
+											<list>
+												<String>XLIFF 2.1</String>
+											</list>
+										</field>
+										<field name="patchHandling">
+											<String>set</String>
+										</field>
+										<field name="anchor">
+											<null/>
+										</field>
+									</poPatch>
+									<poPatch>
+										<field name="fieldPath">
+											<String>priority</String>
+										</field>
+										<field name="index">
+											<Integer>-1</Integer>
+										</field>
+										<field name="value">
+											<Integer>5</Integer>
+										</field>
+										<field name="patchHandling">
+											<String>set</String>
+										</field>
+										<field name="anchor">
+											<null/>
+										</field>
+									</poPatch>
+								</list>
+							</field>
+							<field name="extendedPersistentObjectKey">
+								<String>XLIFF 2.0</String>
+							</field>
+						</documentTypeDescriptorPatch>
+					</field>
+					<field name="name">
+						<String>XLIFF 2.0</String>
+					</field>
+					<field name="schemaDescriptor">
+						<docTypeSchema>
+							<field name="type">
+								<Integer>2</Integer>
+							</field>
+							<field name="uri">
+								<String>${framework}/xsd/2.0/xliff_all.xsd</String>
+							</field>
+						</docTypeSchema>
+					</field>
+					<field name="classpath">
+						<String-array/>
+					</field>
+					<field name="parentClassLoaderID">
+						<null/>
+					</field>
+					<field name="authorExtensionDescriptor">
+						<authorExtension>
+							<field name="cssDescriptors">
+								<cssFile-array>
+									<cssFile>
+										<field name="href">
+											<String>${framework}/css/xliff2.css</String>
+										</field>
+										<field name="title">
+											<String>Default</String>
+										</field>
+										<field name="alternate">
+											<Boolean>false</Boolean>
+										</field>
+									</cssFile>
+									<cssFile>
+										<field name="href">
+											<String>${framework}/css/xliff.css</String>
+										</field>
+										<field name="title">
+											<String>Classic</String>
+										</field>
+										<field name="alternate">
+											<Boolean>false</Boolean>
+										</field>
+									</cssFile>
+									<cssFile>
+										<field name="href">
+											<String>${framework}/css/xliffFocused.css</String>
+										</field>
+										<field name="title">
+											<String>Translate</String>
+										</field>
+										<field name="alternate">
+											<Boolean>false</Boolean>
+										</field>
+									</cssFile>
+									<cssFile>
+										<field name="href">
+											<String>${framework}/css/ditaStyles.css</String>
+										</field>
+										<field name="title">
+											<String>DITA Styles</String>
+										</field>
+										<field name="alternate">
+											<Boolean>true</Boolean>
+										</field>
+									</cssFile>
+								</cssFile-array>
+							</field>
+							<field name="mergeCSSsFromDocument">
+								<Boolean>false</Boolean>
+							</field>
+							<field name="multipleAlternateSelectionEnabled">
+								<Boolean>true</Boolean>
+							</field>
+							<field name="actionDescriptors">
+								<action-array/>
+							</field>
+							<field name="menubarDescriptor">
+								<menu>
+									<field name="label">
+										<String>Menu</String>
+									</field>
+									<field name="accessKey">
+										<null/>
+									</field>
+									<field name="iconPath">
+										<null/>
+									</field>
+									<field name="menuEntriesDescriptorList">
+										<menuEntry-array/>
+									</field>
+									<field name="context">
+										<null/>
+									</field>
+								</menu>
+							</field>
+							<field name="popupMenuDescriptor">
+								<menu>
+									<field name="label">
+										<String>Contextual menu</String>
+									</field>
+									<field name="accessKey">
+										<null/>
+									</field>
+									<field name="iconPath">
+										<null/>
+									</field>
+									<field name="menuEntriesDescriptorList">
+										<menuEntry-array/>
+									</field>
+									<field name="context">
+										<null/>
+									</field>
+								</menu>
+							</field>
+							<field name="toolbarDescriptor">
+								<toolbar>
+									<field name="id">
+										<String>Toolbar</String>
+									</field>
+									<field name="type">
+										<Integer>2</Integer>
+									</field>
+									<field name="largeIconPath">
+										<null/>
+									</field>
+									<field name="smallIconPath">
+										<null/>
+									</field>
+									<field name="toolbarEntriesDescriptorList">
+										<toolbarEntry-array/>
+									</field>
+								</toolbar>
+							</field>
+							<field name="additionalToolbarsDescriptors">
+								<null/>
+							</field>
+							<field name="contextualItems">
+								<contextProvider>
+									<field name="items">
+										<contextItem-array/>
+									</field>
+									<field name="removeItems">
+										<null/>
+									</field>
+								</contextProvider>
+							</field>
+							<field name="tableSupportClassName">
+								<null/>
+							</field>
+							<field name="tableCellSeparatorSupportClassName">
+								<null/>
+							</field>
+							<field name="tableColWidthSupportClassName">
+								<null/>
+							</field>
+							<field name="customReferencesResolver">
+								<null/>
+							</field>
+							<field name="editPropertiesHandler">
+								<null/>
+							</field>
+							<field name="authorExtensionStateListener">
+								<null/>
+							</field>
+							<field name="attributesRecognizer">
+								<null/>
+							</field>
+							<field name="authorActionEventHandler">
+								<null/>
+							</field>
+							<field name="authorImageDecorator">
+								<null/>
+							</field>
+						</authorExtension>
+					</field>
+					<field name="templatesLocations">
+						<String-array>
+							<String>${frameworkDir}/templates/2.0</String>
+						</String-array>
+					</field>
+					<field name="xmlCatalogs">
+						<String-array>
+							<String>${framework}/xsd/2.0/catalog.xml</String>
+						</String-array>
+					</field>
+					<field name="description">
+						<String>XML Localization Interchange File Format (XLIFF).</String>
+					</field>
+					<field name="doctypeRules">
+						<documentTypeRule-array>
+							<documentTypeRule>
+								<field name="namespace">
+									<String>*</String>
+								</field>
+								<field name="rootElem">
+									<String>xliff</String>
+								</field>
+								<field name="fileName">
+									<String>*</String>
+								</field>
+								<field name="publicID">
+									<String>*</String>
+								</field>
+								<field name="javaRuleClass">
+									<String></String>
+								</field>
+								<field name="attributeLocalName">
+									<String>version</String>
+								</field>
+								<field name="attributeNamespace">
+									<String>*</String>
+								</field>
+								<field name="attributeValue">
+									<String>2*</String>
+								</field>
+							</documentTypeRule>
+						</documentTypeRule-array>
+					</field>
+					<field name="scenarios">
+						<scenario-array/>
+					</field>
+					<field name="validationScenarios">
+						<validationScenario-array/>
+					</field>
+					<field name="defaultValidationScenarios">
+						<null/>
+					</field>
+					<field name="defaultTransformationScenarios">
+						<null/>
+					</field>
+					<field name="extensionsBundleClassName">
+						<null/>
+					</field>
+					<field name="useImposedInitialPage">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="imposedInitialPage">
+						<String>Text</String>
+					</field>
+					<field name="elementLocatorExtension">
+						<null/>
+					</field>
+					<field name="schemaManagerFilterExtension">
+						<null/>
+					</field>
+					<field name="authorSWTDndExtension">
+						<null/>
+					</field>
+					<field name="textSWTDndExtension">
+						<null/>
+					</field>
+					<field name="authorSwingDndExtension">
+						<null/>
+					</field>
+					<field name="cssStylesFilterExtension">
+						<null/>
+					</field>
+					<field name="attributesValueEditor">
+						<null/>
+					</field>
+					<field name="priority">
+						<Integer>2</Integer>
+					</field>
+					<field name="xmlNodeCustomizerExtension">
+						<null/>
+					</field>
+					<field name="externalObjectInsertionHandler">
+						<null/>
+					</field>
+					<field name="customAttributeValueEditor">
+						<null/>
+					</field>
+					<field name="textModeExternalObjectInsertionHandler">
+						<null/>
+					</field>
+				</documentTypeDescriptor>
+			</documentTypeDescriptor-array>
+		</entry>
+	</serializableOrderedMap>
+</serialized>

--- a/xsd/2.1/catalog.xml
+++ b/xsd/2.1/catalog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+	<uri name="http://www.w3.org/XML/1998/namespace" uri="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:document:2.0" uri="xliff_core_2.0.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:changetracking:2.1" uri="change_tracking.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:fs:2.0" uri="fs.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:glossary:2.0" uri="glossary.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:matches:2.0" uri="matches.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:metadata:2.0" uri="metadata.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:resourcedata:2.0" uri="resource_data.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:sizerestriction:2.0" uri="size_restriction.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:validation:2.0" uri="validation.xsd"/>
+    <uri name="https://www.w3.org/2005/11/its/" uri="its.xsd"/>
+    <uri name="urn:oasis:names:tc:xliff:itsm:2.1" uri="itsm.xsd"/>
+</catalog>

--- a/xsd/2.1/fs.xsd
+++ b/xsd/2.1/fs.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:fs="urn:oasis:names:tc:xliff:fs:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:fs:2.0">
+
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="fs_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="a"/>
+      <xs:enumeration value="b"/>
+      <xs:enumeration value="bdo"/>
+      <xs:enumeration value="big"/>
+      <xs:enumeration value="blockquote"/>
+      <xs:enumeration value="body"/>
+      <xs:enumeration value="br"/>
+      <xs:enumeration value="button"/>
+      <xs:enumeration value="caption"/>
+      <xs:enumeration value="center"/>
+      <xs:enumeration value="cite"/>
+      <xs:enumeration value="code"/>
+      <xs:enumeration value="col"/>
+      <xs:enumeration value="colgroup"/>
+      <xs:enumeration value="dd"/>
+      <xs:enumeration value="del"/>
+      <xs:enumeration value="div"/>
+      <xs:enumeration value="dl"/>
+      <xs:enumeration value="dt"/>
+      <xs:enumeration value="em"/>
+      <xs:enumeration value="h1"/>
+      <xs:enumeration value="h2"/>
+      <xs:enumeration value="h3"/>
+      <xs:enumeration value="h4"/>
+      <xs:enumeration value="h5"/>
+      <xs:enumeration value="h6"/>
+      <xs:enumeration value="head"/>
+      <xs:enumeration value="hr"/>
+      <xs:enumeration value="html"/>
+      <xs:enumeration value="i"/>
+      <xs:enumeration value="img"/>
+      <xs:enumeration value="label"/>
+      <xs:enumeration value="legend"/>
+      <xs:enumeration value="li"/>
+      <xs:enumeration value="ol"/>
+      <xs:enumeration value="p"/>
+      <xs:enumeration value="pre"/>
+      <xs:enumeration value="q"/>
+      <xs:enumeration value="s"/>
+      <xs:enumeration value="samp"/>
+      <xs:enumeration value="select"/>
+      <xs:enumeration value="small"/>
+      <xs:enumeration value="span"/>
+      <xs:enumeration value="strike"/>
+      <xs:enumeration value="strong"/>
+      <xs:enumeration value="sub"/>
+      <xs:enumeration value="sup"/>
+      <xs:enumeration value="table"/>
+      <xs:enumeration value="tbody"/>
+      <xs:enumeration value="td"/>
+      <xs:enumeration value="tfoot"/>
+      <xs:enumeration value="th"/>
+      <xs:enumeration value="thead"/>
+      <xs:enumeration value="title"/>
+      <xs:enumeration value="tr"/>
+      <xs:enumeration value="tt"/>
+      <xs:enumeration value="u"/>
+      <xs:enumeration value="ul"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Attributes -->
+
+  <xs:attribute name="fs" type="fs:fs_type"/>
+
+  <xs:attribute name="subFs" type="xs:string"/>
+
+</xs:schema>

--- a/xsd/2.1/glossary.xsd
+++ b/xsd/2.1/glossary.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:gls="urn:oasis:names:tc:xliff:glossary:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:glossary:2.0">
+
+
+  <!-- Elements for holding simple glossary data -->
+
+  <xs:element name="glossary">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="gls:glossEntry" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="glossEntry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="gls:term"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="gls:translation" />
+        <xs:element minOccurs="0" maxOccurs="1" ref="gls:definition" />
+        <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="term">
+    <xs:complexType mixed="true">
+      <xs:attribute name="source" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="translation">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="source" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="definition">
+    <xs:complexType mixed="true">
+      <xs:attribute name="source" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/informativeCopiesOf3rdPartySchemas/extensions/change_tracking.xsd
+++ b/xsd/2.1/informativeCopiesOf3rdPartySchemas/extensions/change_tracking.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Change Tracking 2.0 has been demoted to an extension in XLIFF Version 2.1. Work on Change Tracking 2.2 is under way that should become a module again in XLIFF Vesrion 2.2 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ctr="urn:oasis:names:tc:xliff:changetracking:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:changetracking:2.0">
+
+
+  <!-- Elements for change tracking -->
+
+  <xs:element name="changeTrack">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="ctr:revisions"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="revisions">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="ctr:revision"/>
+      </xs:sequence>
+      <xs:attribute name="appliesTo" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="currentVersion" use="optional" type="xs:NMTOKEN"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="revision">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="ctr:item"/>
+      </xs:sequence>
+      <xs:attribute name="author" use="optional"/>
+      <xs:attribute name="datetime" use="optional"/>
+      <xs:attribute name="version" use="optional" type="xs:NMTOKEN"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="item">
+    <xs:complexType mixed="true">
+      <xs:attribute name="property" use="required"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/informativeCopiesOf3rdPartySchemas/readme.txt
+++ b/xsd/2.1/informativeCopiesOf3rdPartySchemas/readme.txt
@@ -1,0 +1,10 @@
+IMPORTANT WARNING
+Schema copies in this sub-folder are provided solely for implementers convenience and are NOT a part of the OASIS multipart product.
+These schemas belong to their respective owners and their use is governed by their owners' respective IPR policies.
+The support schemas are organized in folders per owner/maintainer.
+It is the implemnter's sole responsibility to ensure that their local copies of all schemas are the appropriate up to date versions.
+
+Included 3rd Party Support Schemas:
+-----------------------------------
+http://www.w3.org/2001/xml.xsd [http://www.w3.org/2009/01/xml.xsd] here under /w3c/xml.xsd
+change_tracking.xsd here under /extensions/change_tracking.xsd

--- a/xsd/2.1/informativeCopiesOf3rdPartySchemas/w3c/xml.xsd
+++ b/xsd/2.1/informativeCopiesOf3rdPartySchemas/w3c/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/xsd/2.1/its.xsd
+++ b/xsd/2.1/its.xsd
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  xmlns:its="http://www.w3.org/2005/11/its" xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+  targetNamespace="http://www.w3.org/2005/11/its">
+
+
+  <!-- Import -->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+    schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="ITSVersion">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="2.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="locFilterType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="include"/>
+      <xs:enumeration value="exclude"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="issueType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="terminology"/>
+      <xs:enumeration value="mistranslation"/>
+      <xs:enumeration value="omission"/>
+      <xs:enumeration value="untranslated"/>
+      <xs:enumeration value="addition"/>
+      <xs:enumeration value="duplication"/>
+      <xs:enumeration value="inconsistency"/>
+      <xs:enumeration value="grammar"/>
+      <xs:enumeration value="legal"/>
+      <xs:enumeration value="register"/>
+      <xs:enumeration value="locale-specific-content"/>
+      <xs:enumeration value="locale-violation"/>
+      <xs:enumeration value="style"/>
+      <xs:enumeration value="characters"/>
+      <xs:enumeration value="misspelling"/>
+      <xs:enumeration value="typographical"/>
+      <xs:enumeration value="formatting"/>
+      <xs:enumeration value="inconsistent-entities"/>
+      <xs:enumeration value="numbers"/>
+      <xs:enumeration value="markup"/>
+      <xs:enumeration value="pattern-problem"/>
+      <xs:enumeration value="whitespace"/>
+      <xs:enumeration value="internationalization"/>
+      <xs:enumeration value="length"/>
+      <xs:enumeration value="non-conformance"/>
+      <xs:enumeration value="uncategorized"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="score">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:maxInclusive value="100.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="confidence">
+    <xs:restriction base="xs:double">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="yesNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Attributes -->
+  
+  <xs:attribute name="version" type="its:ITSVersion"/>
+
+  <xs:attribute name="allowedCharacters" type="xs:string"/>
+
+  <xs:attribute name="annotatorsRef" type="xs:string"/>
+
+  <!-- <xs:attribute name="domains" type="xs:string"/> moved to itsm.xsd as it does not exist in the W3C namespace -->
+  
+  <!-- <xs:attribute name="lang" type="xs:language"/> moved to itsm.xsd as it does not exist in the W3C namespace that reuses xml:lang -->
+  
+  <xs:attribute name="localeFilterList" type="xs:string" default="*"/>
+
+  <xs:attribute name="localeFilterType" type="its:locFilterType" default="include"/>
+
+  <xs:attribute name="locQualityIssueComment" type="xs:string"/>
+
+  <xs:attribute name="locQualityIssueEnabled" type="its:yesNo" default="yes"/>
+
+  <xs:attribute name="locQualityIssueProfileRef" type="xs:anyURI"/>
+
+  <xs:attribute name="locQualityIssuesRef" type="xs:anyURI"/>
+
+  <xs:attribute name="locQualityIssueSeverity" type="its:score"/>
+
+  <xs:attribute name="locQualityIssueType" type="its:issueType"/>
+
+  <xs:attribute name="locQualityRatingProfileRef" type="xs:anyURI"/>
+
+  <xs:attribute name="locQualityRatingScore" type="its:score"/>
+
+  <xs:attribute name="locQualityRatingScoreThreshold" type="its:score"/>
+
+  <xs:attribute name="locQualityRatingVote" type="xs:integer"/>
+
+  <xs:attribute name="locQualityRatingVoteThreshold" type="xs:integer"/>
+
+  <xs:attribute name="mtConfidence" type="its:confidence"/>
+
+  <xs:attribute name="org" type="xs:string"/>
+
+  <xs:attribute name="orgRef" type="xs:anyURI"/>
+
+  <xs:attribute name="person" type="xs:string"/>
+
+  <xs:attribute name="personRef" type="xs:anyURI"/>
+
+  <xs:attribute name="provenanceRecordsRef" type="xs:anyURI"/>
+
+  <xs:attribute name="revOrg" type="xs:string"/>
+
+  <xs:attribute name="revOrgRef" type="xs:anyURI"/>
+
+  <xs:attribute name="revPerson" type="xs:string"/>
+
+  <xs:attribute name="revPersonRef" type="xs:anyURI"/>
+
+  <xs:attribute name="revTool" type="xs:string"/>
+
+  <xs:attribute name="revToolRef" type="xs:anyURI"/>
+
+  <xs:attribute name="taClassRef" type="xs:anyURI"/>
+
+  <xs:attribute name="taConfidence" type="its:confidence"/>
+
+  <xs:attribute name="taIdent" type="xs:string"/>
+
+  <xs:attribute name="taIdentRef" type="xs:anyURI"/>
+
+  <xs:attribute name="taSource" type="xs:string"/>
+
+  <xs:attribute name="termConfidence" type="its:confidence"/>
+
+  <xs:attribute name="tool" type="xs:string"/>
+
+  <xs:attribute name="toolRef" type="xs:anyURI"/>
+
+
+  <!-- Elements -->
+
+  <xs:element name="locQualityIssues">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="its:locQualityIssue"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:id" use="required"/>
+      <xs:attribute name="version" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="locQualityIssue">
+    <xs:complexType mixed="false">
+      <xs:attribute name="version" use="optional"/>
+      <xs:attribute name="locQualityIssueType" use="optional"/>
+      <xs:attribute name="locQualityIssueComment" use="optional"/>
+      <xs:attribute name="locQualityIssueSeverity" use="optional"/>
+      <xs:attribute name="locQualityIssueProfileRef" use="optional"/>
+      <xs:attribute name="locQualityIssueEnabled" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="provenanceRecords">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="its:provenanceRecord"/>
+      </xs:sequence>
+      <xs:attribute ref="xml:id" use="required"/>
+      <xs:attribute name="version" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="provenanceRecord">
+    <xs:complexType mixed="false">
+      <xs:attribute name="version" use="optional"/>
+      <xs:attribute name="org" use="optional"/>
+      <xs:attribute name="orgRef" use="optional"/>
+      <xs:attribute name="person" use="optional"/>
+      <xs:attribute name="personRef" use="optional"/>
+      <xs:attribute name="revOrg" use="optional"/>
+      <xs:attribute name="revOrgRef" use="optional"/>
+      <xs:attribute name="revPerson" use="optional"/>
+      <xs:attribute name="revPersonRef" use="optional"/>
+      <xs:attribute name="revTool" use="optional"/>
+      <xs:attribute name="revToolRef" use="optional"/>
+      <xs:attribute name="tool" use="optional"/>
+      <xs:attribute name="toolRef" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/itsm.xsd
+++ b/xsd/2.1/itsm.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  xmlns:itsm="urn:oasis:names:tc:xliff:itsm:2.1" xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+  targetNamespace="urn:oasis:names:tc:xliff:itsm:2.1">
+
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0" schemaLocation="xliff_core_2.0.xsd"/>
+
+
+  
+  <!-- Attributes -->
+
+  <xs:attribute name="domains" type="xs:string"/>
+
+  <xs:attribute name="lang" type="xs:language"/>
+</xs:schema>

--- a/xsd/2.1/matches.xsd
+++ b/xsd/2.1/matches.xsd
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:mtc="urn:oasis:names:tc:xliff:matches:2.0"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:matches:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0"
+      schemaLocation="xliff_core_2.0.xsd"/>
+  <xs:import namespace="urn:oasis:names:tc:xliff:metadata:2.0"
+      schemaLocation="metadata.xsd"/>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="similarity">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:maxInclusive value="100.0"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="typeValues">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="am"/>
+      <xs:enumeration value="mt"/>
+      <xs:enumeration value="icm"/>
+      <xs:enumeration value="idm"/>
+      <xs:enumeration value="tb"/>
+      <xs:enumeration value="tm"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Elements -->
+
+  <xs:element name="matches">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="mtc:match"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="match">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="mda:metadata"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:originalData"/>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:target"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="matchQuality" use="optional" type="mtc:similarity"/>
+      <xs:attribute name="matchSuitability" use="optional" type="mtc:similarity"/>
+      <xs:attribute name="origin" use="optional"/>
+      <xs:attribute name="ref" use="required" type="xs:anyURI"/>
+      <xs:attribute name="reference" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="similarity" use="optional" type="mtc:similarity"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="mtc:typeValues"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/metadata.xsd
+++ b/xsd/2.1/metadata.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:mda="urn:oasis:names:tc:xliff:metadata:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:metadata:2.0">
+
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="appliesTo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="source"/>
+      <xs:enumeration value="target"/>
+      <xs:enumeration value="ignorable"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Elements for holding custom metadata -->
+
+  <xs:element name="metadata">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="mda:metaGroup" />
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="metaGroup">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="mda:metaGroup"/>
+          <xs:element ref="mda:meta"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="category" use="optional"/>
+      <xs:attribute name="appliesTo" use="optional" type="mda:appliesTo"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="meta">
+    <xs:complexType mixed="true">
+      <xs:attribute name="type" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/resource_data.xsd
+++ b/xsd/2.1/resource_data.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:res="urn:oasis:names:tc:xliff:resourcedata:2.0"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:resourcedata:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0"
+      schemaLocation="xliff_core_2.0.xsd"/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+    schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+  
+  <!-- Elements -->
+
+  <xs:element name="resourceData">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="res:resourceItemRef"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="res:resourceItem"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="resourceItemRef">
+    <xs:complexType mixed="false">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="ref" use="required" type="xs:NMTOKEN"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="resourceItem">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="res:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="res:target"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="res:reference"/>
+      </xs:sequence>
+      <xs:attribute name="mimeType" use="optional"/>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="context" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="source">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="target">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="reference">
+    <xs:complexType mixed="false">
+      <xs:attribute name="href" use="required"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/size_restriction.xsd
+++ b/xsd/2.1/size_restriction.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:slr="urn:oasis:names:tc:xliff:sizerestriction:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:sizerestriction:2.0">
+
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="normalization_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="nfc"/>
+      <xs:enumeration value="nfd"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- Attributes for size and length restriction used on core elements-->
+
+  <xs:attribute name="equivStorage" type="xs:string"/>
+
+  <xs:attribute name="sizeInfo" type="xs:string"/>
+
+  <xs:attribute name="sizeInfoRef" type="xs:NMTOKEN"/>
+
+  <xs:attribute name="sizeRestriction" type="xs:string"/>
+
+  <xs:attribute name="storageRestriction" type="xs:string"/>
+
+
+  <!-- Elements for size and length restriction -->
+
+  <xs:element name="profiles">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="slr:normalization" />
+        <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="generalProfile" use="optional"/>
+      <xs:attribute name="storageProfile" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="normalization">
+    <xs:complexType mixed="false">
+      <xs:attribute name="general" use="optional" type="slr:normalization_type" default="none"/>
+      <xs:attribute name="storage" use="optional" type="slr:normalization_type" default="none"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="data">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any maxOccurs="unbounded" minOccurs="0" namespace="##other" processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="profile" use="required"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/validation.xsd
+++ b/xsd/2.1/validation.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:val="urn:oasis:names:tc:xliff:validation:2.0"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:validation:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="urn:oasis:names:tc:xliff:document:2.0"
+      schemaLocation="xliff_core_2.0.xsd"/>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="normalization_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="nfc"/>
+      <xs:enumeration value="nfd"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Elements -->
+
+  <xs:element name="validation">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="val:rule"/>
+      </xs:sequence>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="rule">
+    <xs:complexType mixed="false">
+      <xs:attribute name="isPresent" use="optional"/>
+      <xs:attribute name="occurs" use="optional" type="xs:positiveInteger"/>
+      <xs:attribute name="isNotPresent" use="optional"/>
+      <xs:attribute name="startsWith" use="optional"/>
+      <xs:attribute name="endsWith" use="optional"/>
+      <xs:attribute name="existsInSource" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="caseSensitive" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="normalization" use="optional" type="val:normalization_type" default="nfc"/>
+      <xs:attribute name="disabled" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/xsd/2.1/xliff_all.xsd
+++ b/xsd/2.1/xliff_all.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:import schemaLocation="xliff_core_2.0.xsd" namespace="urn:oasis:names:tc:xliff:document:2.0"/>
+    <!-- CTR does not have module status in XLIFF 2.1 -->
+    <xs:import schemaLocation="informativeCopiesOf3rdPartySchemas/extensions/change_tracking.xsd" namespace="urn:oasis:names:tc:xliff:changetracking:2.0"/>
+    <xs:import schemaLocation="fs.xsd" namespace="urn:oasis:names:tc:xliff:fs:2.0"/>
+    <xs:import schemaLocation="glossary.xsd" namespace="urn:oasis:names:tc:xliff:glossary:2.0"/>
+    <xs:import schemaLocation="matches.xsd" namespace="urn:oasis:names:tc:xliff:matches:2.0"/>
+    <xs:import schemaLocation="metadata.xsd" namespace="urn:oasis:names:tc:xliff:metadata:2.0"/>
+    <xs:import schemaLocation="resource_data.xsd" namespace="urn:oasis:names:tc:xliff:resourcedata:2.0"/>
+    <xs:import schemaLocation="size_restriction.xsd" namespace="urn:oasis:names:tc:xliff:sizerestriction:2.0"/>
+    <xs:import schemaLocation="itsm.xsd" namespace="urn:oasis:names:tc:xliff:itsm:2.1"/>
+    <xs:import schemaLocation="its.xsd" namespace="http://www.w3.org/2005/11/its"/>
+</xs:schema>

--- a/xsd/2.1/xliff_core_2.0.xsd
+++ b/xsd/2.1/xliff_core_2.0.xsd
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified"
+    xmlns:xlf="urn:oasis:names:tc:xliff:document:2.0"
+    targetNamespace="urn:oasis:names:tc:xliff:document:2.0">
+
+  <!-- Import -->
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+      schemaLocation="informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"/>
+
+  <!-- Element Group -->
+
+  <xs:group name="inline">
+    <xs:choice>
+      <xs:element ref="xlf:cp"/>
+      <xs:element ref="xlf:ph"/>
+      <xs:element ref="xlf:pc"/>
+      <xs:element ref="xlf:sc"/>
+      <xs:element ref="xlf:ec"/>
+      <xs:element ref="xlf:mrk"/>
+      <xs:element ref="xlf:sm"/>
+      <xs:element ref="xlf:em"/>
+    </xs:choice>
+  </xs:group>
+
+  <!-- Attribute Types -->
+
+  <xs:simpleType name="yesNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="yesNoFirstNo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="yes"/>
+      <xs:enumeration value="firstNo"/>
+      <xs:enumeration value="no"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="dirValue">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ltr"/>
+      <xs:enumeration value="rtl"/>
+      <xs:enumeration value="auto"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="appliesTo">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="source"/>
+      <xs:enumeration value="target"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="userDefinedValue">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\s:]+:[^\s:]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="attrType_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fmt"/>
+      <xs:enumeration value="ui"/>
+      <xs:enumeration value="quote"/>
+      <xs:enumeration value="link"/>
+      <xs:enumeration value="image"/>
+      <xs:enumeration value="other"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="typeForMrkValues">
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="generic"/>
+      <xs:enumeration value="comment"/>
+      <xs:enumeration value="term"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="attrType_typeForMrk">
+    <xs:union memberTypes="xlf:typeForMrkValues xlf:userDefinedValue"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="priorityValue">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:minInclusive value="1"/>
+      <xs:maxInclusive value="10"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="stateType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="initial"/>
+      <xs:enumeration value="translated"/>
+      <xs:enumeration value="reviewed"/>
+      <xs:enumeration value="final"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Structural Elements -->
+
+  <xs:element name="xliff">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:file"/>
+      </xs:sequence>
+      <xs:attribute name="version" use="required"/>
+      <xs:attribute name="srcLang" use="required" type="xs:language"/>
+      <xs:attribute name="trgLang" use="optional" type="xs:language"/>
+      <xs:attribute ref="xml:space" use="optional" default="default"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="file">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:skeleton"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="xlf:unit"/>
+          <xs:element ref="xlf:group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="original" use="optional"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="skeleton">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+      </xs:sequence>
+      <xs:attribute name="href" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="group">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="xlf:unit"/>
+          <xs:element ref="xlf:group"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="optional"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="unit">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"
+            processContents="lax"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:notes"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:originalData"/>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+          <xs:element ref="xlf:segment"/>
+          <xs:element ref="xlf:ignorable"/>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="name" use="optional"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="srcDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="trgDir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:attribute name="type" use="optional" type="xlf:userDefinedValue"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="segment">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:target"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="canResegment" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="state" use="optional" type="xlf:stateType" default="initial"/>
+      <xs:attribute name="subState" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ignorable">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="1" ref="xlf:source"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="xlf:target"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="notes">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:note"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="note">
+    <xs:complexType mixed="true">
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="appliesTo" use="optional" type="xlf:appliesTo"/>
+      <xs:attribute name="category" use="optional"/>
+      <xs:attribute name="priority" use="optional" type="xlf:priorityValue" default="1"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="originalData">
+    <xs:complexType mixed="false">
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="xlf:data"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="data">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="xlf:cp"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue" default="auto"/>
+      <xs:attribute ref="xml:space" use="optional" fixed="preserve"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="source">
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="target">
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute ref="xml:lang" use="optional"/>
+      <xs:attribute ref="xml:space" use="optional"/>
+      <xs:attribute name="order" use="optional" type="xs:positiveInteger"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inline Elements -->
+
+  <xs:element name="cp">
+    <!-- Code Point -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="hex" use="required" type="xs:hexBinary"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ph">
+    <!-- Placeholder -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pc">
+    <!-- Paired Code -->
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dispEnd" use="optional"/>
+      <xs:attribute name="dispStart" use="optional"/>
+      <xs:attribute name="equivEnd" use="optional"/>
+      <xs:attribute name="equivStart" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRefEnd" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRefStart" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlowsEnd" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subFlowsStart" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sc">
+    <!-- Start Code -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="isolated" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="ec">
+    <!-- End Code -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="canCopy" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canDelete" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canOverlap" use="optional" type="xlf:yesNo" default="yes"/>
+      <xs:attribute name="canReorder" use="optional" type="xlf:yesNoFirstNo" default="yes"/>
+      <xs:attribute name="copyOf" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dataRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="dir" use="optional" type="xlf:dirValue"/>
+      <xs:attribute name="disp" use="optional"/>
+      <xs:attribute name="equiv" use="optional"/>
+      <xs:attribute name="id" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="isolated" use="optional" type="xlf:yesNo" default="no"/>
+      <xs:attribute name="startRef" use="optional" type="xs:NMTOKEN"/>
+      <xs:attribute name="subFlows" use="optional" type="xs:NMTOKENS"/>
+      <xs:attribute name="subType" use="optional" type="xlf:userDefinedValue"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_type"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="mrk">
+    <!-- Annotation Marker -->
+    <xs:complexType mixed="true">
+      <xs:group ref="xlf:inline" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_typeForMrk"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="value" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sm">
+    <!-- Start Annotation Marker -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="id" use="required" type="xs:NMTOKEN"/>
+      <xs:attribute name="translate" use="optional" type="xlf:yesNo"/>
+      <xs:attribute name="type" use="optional" type="xlf:attrType_typeForMrk"/>
+      <xs:attribute name="ref" use="optional" type="xs:anyURI"/>
+      <xs:attribute name="value" use="optional"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="em">
+    <!-- End Annotation Marker -->
+    <xs:complexType mixed="false">
+      <xs:attribute name="startRef" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>


### PR DESCRIPTION
moved the custom sch to custom sch subfolder
added all xsd, sch, and NVDL from XLIFF 2.1 Candidate OASIS Standard into 2.1 subfolders
Note: 2.1 validation artifacts can be used to validate 2.0